### PR TITLE
[#4] CLAUDE.md System 1 필터 설명 정정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Last updated: 2026-02-19
 ### 2.1 System 1 (Short-term breakout)
 
 - 진입: 20일 돌파 브레이크아웃
-- 필터: 최근 55일 수익성/유효성 확인
+- 필터: 직전 거래 수익 시 20일 돌파 스킵 (단, 55일 돌파는 failsafe 진입 허용)
 - 청산: 10일 하향 이탈
 
 ### 2.2 System 2 (Long-term breakout)


### PR DESCRIPTION
## Summary

- CLAUDE.md 2.1절 System 1 필터 설명이 실제 규칙과 불일치하여 정정
- 변경 전: `필터: 최근 55일 수익성/유효성 확인` (모호, 오독 가능)
- 변경 후: `필터: 직전 거래 수익 시 20일 돌파 스킵 (단, 55일 돌파는 failsafe 진입 허용)`

## Test plan

- [x] 문서 변경만 — 코드 변경 없음

관련: #4, PR #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)