### PR TITLE
[#6] 시그널 스크립트 테스트 추가: 청산/스톱로스/리스크 통합

### DIFF
--- a/src/analytics.py
+++ b/src/analytics.py
@@ -396,7 +396,7 @@ def calculate_sharpe_ratio(returns: list, risk_free_rate: float = 0.03) -> float
     variance = sum((r - mean_return) ** 2 for r in returns) / (n - 1)
     std_return = math.sqrt(variance)
 
-    if std_return == 0:
+    if std_return < 1e-10:
         return 0.0
 
     # 일별 무위험 수익률로 변환 (거래일 252일 기준)

--- a/tests/test_backtester_live_equivalence.py
+++ b/tests/test_backtester_live_equivalence.py
@@ -18,7 +18,6 @@ Issue #18: 동일한 시장 상황에서 backtester와 live checker가 동일한
 
 import sys
 from pathlib import Path
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -462,16 +461,11 @@ class TestShouldAllowEntryEquivalence:
     def test_system2_with_profitable_true_behavior(self):
         """_should_allow_entry(2, True, ...) 동작 문서화.
 
-        _should_allow_entry(2, True, ...) 는 55일 돌파 여부와 무관하게 False를 반환한다.
-        failsafe(55일 돌파 override)는 system == 1 에만 적용되기 때문이다.
-
-        프로덕션에서는 _was_last_trade_profitable()이 system != 1 이면
-        항상 False를 반환하므로 이 경로는 실행되지 않는다.
+        System 2는 필터 없음 → is_profitable 값에 관계없이 항상 True 반환.
+        함수 첫 줄에서 system == 2 조기 반환으로 명시적 처리 (PR #24).
         """
-        # 55일 미돌파: False (하지만 프로덕션에서 호출되지 않는 경로)
-        assert _should_allow_entry(2, True, False) is False
-        # 55일 돌파여도 system=2 이면 failsafe 미적용 -> False
-        assert _should_allow_entry(2, True, True) is False
+        assert _should_allow_entry(2, True, False) is True
+        assert _should_allow_entry(2, True, True) is True
 
     def test_system2_filter_bypass_mechanism(self):
         """System 2 필터 우회 메커니즘의 동치성 검증.


### PR DESCRIPTION
## Summary
- `check_exit_signals()` 테스트 10건: System 1/2 × LONG/SHORT 청산, 경계값, 구조 검증
- `check_stop_loss()` 함수 추출 + 테스트 12건: LONG/SHORT 발동/미발동/경계값 parametrized
- 리스크 매니저 통합 테스트 2건: 한도 내 통과, 방향 한도(12 Units) 초과 거부
- `calculate_sharpe_ratio` 부동소수점 정밀도 수정: `std == 0` → `std < 1e-10`
- `test_backtester_live_equivalence` System 2 정책 PR #24 반영

테스트: 26 → 50건 (check_positions), 전체 638 passed

Ref #6

## Test plan
- [x] `pytest tests/test_check_positions.py` — 50 pass (기존 26 + 신규 24)
- [x] `pytest tests/test_analytics.py::TestRatios::test_sharpe_ratio_constant_returns` — pass
- [x] `pytest` 전체 — 638 pass, 0 fail
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)