### PR TITLE
한국 종목 표시명 기능 추가 (get_display_name)

### DIFF
--- a/src/universe_manager.py
+++ b/src/universe_manager.py
@@ -133,5 +133,18 @@ class UniverseManager:
         """활성화된 전체 심볼 리스트 (이름 포함 튜플이 아닌 순수 심볼)"""
         return self.get_enabled_symbols()
 
+    def get_display_name(self, symbol: str) -> str:
+        """알림용 표시 이름 반환.
+
+        한국 종목(.KS/.KQ): "삼성전자 005930.KS"
+        미국/기타: 심볼 그대로 "SPY"
+        """
+        asset = self.assets.get(symbol)
+        if not asset or asset.name == symbol:
+            return symbol
+        if symbol.endswith(".KS") or symbol.endswith(".KQ"):
+            return f"{asset.name} {symbol}"
+        return asset.name
+
     def get_group_mapping(self) -> Dict[str, AssetGroup]:
         return {s: a.group for s, a in self.assets.items()}

--- a/tests/test_universe_manager.py
+++ b/tests/test_universe_manager.py
@@ -277,3 +277,60 @@ class TestGetGroupMapping:
         um = UniverseManager()
         mapping = um.get_group_mapping()
         assert len(mapping) == len(um.assets)
+
+
+class TestGetDisplayName:
+    """get_display_name() 메서드 단위 테스트"""
+
+    @pytest.fixture
+    def um_with_korean_and_us(self):
+        yaml_content = """
+symbols:
+  kr_equity:
+    - {symbol: "005930.KS", name: "삼성전자", group: kr_equity}
+    - {symbol: "035420.KQ", name: "NAVER", group: kr_equity}
+  us_equity:
+    - {symbol: SPY, name: "S&P 500 ETF", group: us_equity}
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            yield UniverseManager(yaml_path=f.name)
+        os.unlink(f.name)
+
+    def test_korean_ks_returns_name_symbol_format(self, um_with_korean_and_us):
+        """한국 .KS 종목은 "이름 심볼" 형식 반환"""
+        result = um_with_korean_and_us.get_display_name("005930.KS")
+        assert result == "삼성전자 005930.KS"
+
+    def test_korean_kq_returns_name_symbol_format(self, um_with_korean_and_us):
+        """한국 .KQ 종목은 "이름 심볼" 형식 반환"""
+        result = um_with_korean_and_us.get_display_name("035420.KQ")
+        assert result == "NAVER 035420.KQ"
+
+    def test_us_stock_returns_name_only(self, um_with_korean_and_us):
+        """미국 종목은 이름만 반환"""
+        result = um_with_korean_and_us.get_display_name("SPY")
+        assert result == "S&P 500 ETF"
+
+    def test_unknown_symbol_returns_symbol_as_is(self, um_with_korean_and_us):
+        """유니버스에 없는 심볼은 심볼 그대로 반환"""
+        result = um_with_korean_and_us.get_display_name("UNKNOWN")
+        assert result == "UNKNOWN"
+
+    def test_symbol_where_name_equals_symbol_returns_symbol(self):
+        """name이 심볼과 동일한 경우 심볼 그대로 반환"""
+        yaml_content = """
+symbols:
+  us_equity:
+    - {symbol: AAPL, name: AAPL, group: us_equity}
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            try:
+                um = UniverseManager(yaml_path=f.name)
+                result = um.get_display_name("AAPL")
+                assert result == "AAPL"
+            finally:
+                os.unlink(f.name)


### PR DESCRIPTION
## Summary
- `UniverseManager.get_display_name(symbol)` 메서드 추가
- 한국 종목(.KS/.KQ): `"삼성전자 005930.KS"` 형식으로 반환
- 미국/기타 종목: 종목명만 반환 (예: `"S&P 500 ETF"`)
- 미등록 심볼: 심볼 코드 그대로 반환

## Test plan
- [x] 테스트 5건 추가 (KS/KQ/US/미등록/동명 케이스)
- [x] 33/33 universe_manager 테스트 통과
- [x] 기존 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)