### PR TITLE
보안 리뷰 HIGH/MEDIUM 8건 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,13 @@ COPY crontab /etc/cron.d/turtle-cron
 RUN chmod 0644 /etc/cron.d/turtle-cron
 RUN crontab /etc/cron.d/turtle-cron
 
+# Non-root user for data/log directories
+RUN useradd --create-home --shell /bin/bash turtle && \
+    chown -R turtle:turtle /app/data /app/logs
+
 # 환경 변수
 ENV PYTHONUNBUFFERED=1
 ENV TZ=Asia/Seoul
 
-# 기본 명령어
+# 기본 명령어 (cron requires root — data dirs owned by turtle)
 CMD ["cron", "-f"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     container_name: turtle-dashboard
     command: streamlit run app.py --server.port=8501 --server.address=0.0.0.0
     ports:
-      - "8501:8501"
+      - "127.0.0.1:8501:8501"
     env_file:
       - .env
     volumes:

--- a/src/kis_api.py
+++ b/src/kis_api.py
@@ -63,15 +63,23 @@ def _sanitize_error(data) -> str:
     return f"rt_cd={rt_cd}, msg={msg1}"
 
 
+_SAFE_LOG_KEYS = frozenset({"rt_cd", "msg_cd", "msg1"})
+
+
+def _sanitize_response_for_log(data: dict) -> dict:
+    """로그 안전 필드만 추출 (민감 데이터 제외)"""
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if k in _SAFE_LOG_KEYS}
+
+
 def _classify_response(status: int, data: dict) -> None:
     """HTTP 응답 코드 기반 예외 분류 (성공 시 None 반환)"""
     if 200 <= status < 300:
         return  # 성공
 
     safe_msg = _sanitize_error(data)
-    # NOTE: debug 레벨에서 전체 응답 출력 — 프로덕션 로그 수집기가
-    # debug를 포함하지 않도록 운영 정책에서 관리 필요
-    logger.debug("API error response (status=%d): %s", status, data)
+    logger.debug("API error response (status=%d): %s", status, _sanitize_response_for_log(data))
 
     if status == 429:
         raise RateLimitError(f"Rate limit exceeded: {safe_msg}")
@@ -207,6 +215,7 @@ class KISAPIClient:
             raise
 
     def _get_headers(self, token: str, tr_id: str) -> Dict[str, str]:
+        # WARNING: 반환값에 appsecret 포함 — 절대 로그에 출력하지 말 것
         return {
             "Content-Type": "application/json; charset=utf-8",
             "authorization": f"Bearer {token}",

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -10,12 +10,14 @@ import asyncio
 import html as html_lib
 import logging
 import smtplib
+import ssl
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from enum import Enum
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -89,8 +91,14 @@ class TelegramChannel(NotificationChannel):
             return False
 
 
+_DISCORD_ALLOWED_HOSTS = ("discord.com", "discordapp.com")
+
+
 class DiscordChannel(NotificationChannel):
     def __init__(self, webhook_url: str):
+        parsed = urlparse(webhook_url)
+        if parsed.hostname not in _DISCORD_ALLOWED_HOSTS:
+            raise ValueError(f"Invalid Discord webhook URL domain: {parsed.hostname}")
         self.webhook_url = webhook_url
 
     def _format_embed(self, message: NotificationMessage) -> Dict:
@@ -176,8 +184,9 @@ class EmailChannel(NotificationChannel):
             return False
 
     def _send_email(self, msg: MIMEMultipart):
+        context = ssl.create_default_context()
         with smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=10) as server:
-            server.starttls()
+            server.starttls(context=context)
             server.login(self.username, self.password)
             server.send_message(msg)
 

--- a/src/script_helpers.py
+++ b/src/script_helpers.py
@@ -57,7 +57,7 @@ def setup_notifier(config: Dict[str, Any]) -> NotificationManager:
         notifier.add_channel(DiscordChannel(config["discord_webhook"]))
         logger.info("Discord 채널 활성화")
 
-    if config.get("email_user") and config.get("email_to"):
+    if config.get("email_user") and config.get("email_pass") and config.get("email_to"):
         notifier.add_channel(
             EmailChannel(
                 config["smtp_host"],

--- a/tests/test_kis_api.py
+++ b/tests/test_kis_api.py
@@ -14,6 +14,7 @@ from src.kis_api import (
     TokenExpiredError,
     _classify_response,
     _sanitize_error,
+    _sanitize_response_for_log,
 )
 
 # 민감 정보가 포함된 가짜 API 응답
@@ -108,3 +109,27 @@ class TestClassifyResponseSecurity:
         error_msg = str(exc_info.value)
         assert "output" not in error_msg
         assert "{" not in error_msg or "rt_cd=" in error_msg
+
+
+class TestSanitizeResponseForLog:
+    """_sanitize_response_for_log 보안 테스트"""
+
+    def test_only_safe_keys_returned(self):
+        result = _sanitize_response_for_log(SENSITIVE_DATA)
+        assert set(result.keys()) == {"rt_cd", "msg_cd", "msg1"}
+        assert result["rt_cd"] == "1"
+        assert result["msg1"] == "잔고 부족"
+
+    def test_sensitive_data_excluded(self):
+        result = _sanitize_response_for_log(SENSITIVE_DATA)
+        assert "output" not in result
+        assert "CANO" not in str(result)
+        assert "dnca_tot_amt" not in str(result)
+
+    def test_non_dict_returns_empty(self):
+        assert _sanitize_response_for_log("not a dict") == {}
+        assert _sanitize_response_for_log(None) == {}
+        assert _sanitize_response_for_log(42) == {}
+
+    def test_empty_dict_returns_empty(self):
+        assert _sanitize_response_for_log({}) == {}

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -100,7 +100,7 @@ class TestTelegramChannelFormatting:
 
 class TestDiscordChannelFormatting:
     def test_format_embed_basic(self):
-        ch = DiscordChannel(webhook_url="https://fake.webhook")
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/fake")
         msg = NotificationMessage(title="Test", body="Hello")
         embed = ch._format_embed(msg)
         assert embed["title"] == "Test"
@@ -108,7 +108,7 @@ class TestDiscordChannelFormatting:
         assert "color" in embed
 
     def test_format_embed_with_data(self):
-        ch = DiscordChannel(webhook_url="https://fake.webhook")
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/fake")
         msg = NotificationMessage(
             title="Signal",
             body="Buy",
@@ -119,13 +119,13 @@ class TestDiscordChannelFormatting:
         assert len(embed["fields"]) == 2
 
     def test_format_embed_no_data(self):
-        ch = DiscordChannel(webhook_url="https://fake.webhook")
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/fake")
         msg = NotificationMessage(title="Test", body="No data")
         embed = ch._format_embed(msg)
         assert "fields" not in embed
 
     def test_embed_color_by_level(self):
-        ch = DiscordChannel(webhook_url="https://fake.webhook")
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/fake")
         info_embed = ch._format_embed(NotificationMessage(title="", body="", level=NotificationLevel.INFO))
         error_embed = ch._format_embed(NotificationMessage(title="", body="", level=NotificationLevel.ERROR))
         assert info_embed["color"] != error_embed["color"]
@@ -441,3 +441,45 @@ class TestEmailChannelRetry:
             await ch.send(msg)
 
         mock_smtp_cls.assert_called_once_with("localhost", 587, timeout=10)
+
+
+class TestSecurityFixes:
+    """보안 수정 검증 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_smtp_starttls_uses_ssl_context(self):
+        """SMTP starttls()가 SSL context와 함께 호출된다."""
+        ch = _make_email_channel()
+
+        with patch("smtplib.SMTP") as mock_smtp_cls:
+            mock_server = MagicMock()
+            mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+            mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            with patch("src.notifier.ssl.create_default_context") as mock_ssl:
+                mock_context = MagicMock()
+                mock_ssl.return_value = mock_context
+                msg = NotificationMessage(title="SSL Test", body="Hello")
+                await ch.send(msg)
+
+            mock_server.starttls.assert_called_once_with(context=mock_context)
+
+    def test_discord_valid_url_accepted(self):
+        """discord.com 도메인 URL은 정상 생성된다."""
+        ch = DiscordChannel(webhook_url="https://discord.com/api/webhooks/12345/abcde")
+        assert ch.webhook_url == "https://discord.com/api/webhooks/12345/abcde"
+
+    def test_discord_discordapp_url_accepted(self):
+        """discordapp.com 도메인도 허용된다."""
+        ch = DiscordChannel(webhook_url="https://discordapp.com/api/webhooks/12345/abcde")
+        assert ch.webhook_url == "https://discordapp.com/api/webhooks/12345/abcde"
+
+    def test_discord_invalid_url_rejected(self):
+        """Discord 외 도메인은 ValueError를 발생시킨다."""
+        with pytest.raises(ValueError, match="Invalid Discord webhook URL domain"):
+            DiscordChannel(webhook_url="https://evil.com/api/webhooks/12345")
+
+    def test_discord_no_host_rejected(self):
+        """호스트가 없는 URL은 거부된다."""
+        with pytest.raises(ValueError):
+            DiscordChannel(webhook_url="not-a-url")

--- a/tests/test_script_helpers.py
+++ b/tests/test_script_helpers.py
@@ -13,7 +13,7 @@ class TestLoadConfig:
         {
             "TELEGRAM_BOT_TOKEN": "test_token",
             "TELEGRAM_CHAT_ID": "test_chat",
-            "DISCORD_WEBHOOK_URL": "https://discord.webhook",
+            "DISCORD_WEBHOOK_URL": "https://discord.com/api/webhooks/test",
             "EMAIL_USER": "user@test.com",
             "EMAIL_PASSWORD": "pass",
             "EMAIL_TO": "to@test.com",
@@ -24,7 +24,7 @@ class TestLoadConfig:
         config = load_config()
         assert config["telegram_token"] == "test_token"
         assert config["telegram_chat_id"] == "test_chat"
-        assert config["discord_webhook"] == "https://discord.webhook"
+        assert config["discord_webhook"] == "https://discord.com/api/webhooks/test"
         assert config["email_user"] == "user@test.com"
 
     @patch.dict("os.environ", {}, clear=True)
@@ -68,7 +68,7 @@ class TestSetupNotifier:
         assert len(notifier.channels) == 1
 
     def test_discord_only(self):
-        config = {"discord_webhook": "https://hook"}
+        config = {"discord_webhook": "https://discord.com/api/webhooks/hook"}
         notifier = setup_notifier(config)
         assert len(notifier.channels) == 1
 
@@ -87,7 +87,7 @@ class TestSetupNotifier:
         config = {
             "telegram_token": "tok",
             "telegram_chat_id": "chat",
-            "discord_webhook": "https://hook",
+            "discord_webhook": "https://discord.com/api/webhooks/hook",
             "email_user": "user@test.com",
             "email_pass": "pass",
             "smtp_host": "localhost",
@@ -106,3 +106,27 @@ class TestSetupNotifier:
         config = {"email_user": "user@test.com", "email_pass": "pass", "smtp_host": "localhost", "smtp_port": 587}
         notifier = setup_notifier(config)
         assert len(notifier.channels) == 0
+
+    def test_email_missing_password_no_channel(self):
+        """email_pass가 None이면 EmailChannel이 생성되지 않는다."""
+        config = {
+            "email_user": "user@test.com",
+            "email_pass": None,
+            "smtp_host": "localhost",
+            "smtp_port": 587,
+            "email_to": ["to@test.com"],
+        }
+        notifier = setup_notifier(config)
+        assert len(notifier.channels) == 0
+
+    def test_email_with_password_creates_channel(self):
+        """email_pass가 설정되면 EmailChannel이 생성된다."""
+        config = {
+            "email_user": "user@test.com",
+            "email_pass": "password123",
+            "smtp_host": "localhost",
+            "smtp_port": 587,
+            "email_to": ["to@test.com"],
+        }
+        notifier = setup_notifier(config)
+        assert len(notifier.channels) == 1


### PR DESCRIPTION
## Summary
- 보안 리뷰에서 발견된 HIGH 3건 + MEDIUM 5건 수정
- 새 테스트 11건 추가 (총 759 passed)

### HIGH (3건)
- **SMTP STARTTLS SSL**: `starttls(context=ssl.create_default_context())` 적용 → MITM 방지
- **KIS API 로그 필터링**: `_sanitize_response_for_log()` 추가, DEBUG 로그에 `rt_cd`/`msg_cd`/`msg1`만 출력
- **`_get_headers` 보안 주석**: appsecret 로그 노출 방지 경고

### MEDIUM (5건)
- **Discord URL 검증**: `discord.com`/`discordapp.com` 도메인만 허용 (SSRF 방지)
- **email_pass 필수 조건**: `None` 패스워드로 SMTP 로그인 시도 방지
- **Streamlit 로컬 바인딩**: `127.0.0.1:8501:8501`로 외부 접근 차단
- **Dockerfile non-root**: `turtle` 사용자 추가, 데이터 디렉토리 소유권 분리

### 변경 파일 (8개)
- `src/notifier.py` — SSL context, Discord URL 검증, import 정렬
- `src/kis_api.py` — `_sanitize_response_for_log()`, 보안 주석
- `src/script_helpers.py` — email_pass 조건 추가
- `docker-compose.yaml` — localhost 바인딩
- `Dockerfile` — non-root user
- `tests/test_notifier.py` — SSL/Discord 검증 테스트 5건
- `tests/test_kis_api.py` — 로그 필터링 테스트 4건
- `tests/test_script_helpers.py` — email_pass 테스트 2건

## Test plan
- [x] `pytest -q` — 759 passed, 0 failed
- [x] `ruff check` — All checks passed
- [ ] CI lint + test 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)