### PR TITLE
[#65] 버전 메타데이터 단일 원천(pyproject.toml) 동기화

### DIFF
--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -29,6 +29,13 @@ pytest tests/ -q  # 전체 테스트 통과 확인
 python scripts/health_check.py  # Python Version 항목 확인
 ```
 
+### 버전 정책
+
+- **Single Source of Truth**: `pyproject.toml`의 `[project] version` 필드
+- `src/__version__`은 `importlib.metadata`를 통해 동적 조회 (하드코딩 금지)
+- 로컬 개발 시 (`pip install -e .` 미실행) `pyproject.toml` 직접 파싱으로 fallback
+- `/release` 커맨드 실행 시 `pyproject.toml`만 갱신하면 자동 반영
+
 ## 실거래 전 체크리스트
 
 - 백테스트 성능 임계치 재확인(수익/드로우다운/거래빈도)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,30 @@
-"""
-터틀 트레이딩 시스템 v3.2
-"""
+"""터틀 트레이딩 시스템."""
 
-__version__ = "3.2.0"
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _get_version() -> str:
+    """패키지 버전을 동적으로 조회한다.
+
+    1차: importlib.metadata (pip install 환경)
+    2차: pyproject.toml 직접 파싱 (로컬 개발 환경)
+    3차: "unknown" fallback
+    """
+    try:
+        return version("turtle-trading")
+    except PackageNotFoundError:
+        pass
+    try:
+        import tomllib
+        from pathlib import Path
+
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        if pyproject.exists():
+            with open(pyproject, "rb") as f:
+                return tomllib.load(f)["project"]["version"]
+    except (KeyError, FileNotFoundError, Exception):
+        pass
+    return "unknown"
+
+
+__version__ = _get_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,33 @@
+"""버전 메타데이터 정합성 테스트."""
+
+import re
+
+import src
+
+
+class TestVersionMetadata:
+    """__version__ 검증 테스트."""
+
+    def test_version_is_not_unknown(self):
+        """버전이 'unknown'이 아닌 실제 값이어야 한다."""
+        assert src.__version__ != "unknown"
+
+    def test_version_format_semver(self):
+        """시맨틱 버전 형식(X.Y.Z)을 따라야 한다."""
+        pattern = r"^\d+\.\d+\.\d+$"
+        assert re.match(pattern, src.__version__), (
+            f"Version '{src.__version__}' does not match semver format X.Y.Z"
+        )
+
+    def test_version_matches_pyproject(self):
+        """src.__version__이 pyproject.toml의 version과 일치해야 한다."""
+        import tomllib
+        from pathlib import Path
+
+        pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject_version = tomllib.load(f)["project"]["version"]
+
+        assert src.__version__ == pyproject_version, (
+            f"src.__version__={src.__version__} != pyproject.toml={pyproject_version}"
+        )


### PR DESCRIPTION
## Summary
- `src/__init__.py`: 하드코딩 `__version__ = "3.2.0"` 제거, `importlib.metadata` 동적 조회 도입
- 2차 fallback: `pyproject.toml` 직접 파싱 (`tomllib`, 로컬 개발 환경 대응)
- `tests/test_version.py`: 버전 정합성/형식 검증 테스트 3건 추가
- `docs/operations-guide.md`: 버전 정책(SSOT) 명시

## Test plan
- [x] `test_version_is_not_unknown` — 버전이 실제 값으로 해석됨
- [x] `test_version_format_semver` — X.Y.Z 형식 준수
- [x] `test_version_matches_pyproject` — pyproject.toml과 일치
- [x] 전체 테스트 769건 통과

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)