### PR TITLE
[#78] remove_position 음수 입력 가드 추가

### DIFF
--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -95,6 +95,11 @@ class PortfolioRiskManager:
         NOTE: n_value는 add_position 시점과 동일한 값을 전달해야 한다.
         불일치 시 total_n_exposure에 누적 오차가 발생할 수 있다.
         """
+        if n_value < 0:
+            raise ValueError(f"n_value must be non-negative, got {n_value}")
+        if units <= 0:
+            raise ValueError(f"units must be positive, got {units}")
+
         group = self.get_group(symbol)
 
         # 실제 보유 수량으로 제거량 클램핑 (공유 필드 과다 차감 방지)

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -314,6 +314,18 @@ class TestInputValidation:
         assert risk_manager.state.short_units == prev_short_units
         assert risk_manager.state.total_n_exposure == pytest.approx(prev_n_exposure)
 
+    def test_remove_position_negative_units_raises(self, risk_manager):
+        """remove_position: units가 음수이면 ValueError 발생"""
+        risk_manager.add_position("SPY", 2, 1.5, Direction.LONG)
+        with pytest.raises(ValueError, match="units must be positive"):
+            risk_manager.remove_position("SPY", -1, Direction.LONG, n_value=1.5)
+
+    def test_remove_position_negative_n_value_raises(self, risk_manager):
+        """remove_position: n_value가 음수이면 ValueError 발생"""
+        risk_manager.add_position("SPY", 2, 1.5, Direction.LONG)
+        with pytest.raises(ValueError, match="n_value must be non-negative"):
+            risk_manager.remove_position("SPY", 1, Direction.LONG, n_value=-1.0)
+
 
 class TestShortDirectionLimit:
     """숏 방향 한도: 12 Units (lines 64-65)"""


### PR DESCRIPTION
## Summary
- `remove_position`에 `units <= 0`, `n_value < 0` 가드 추가 (`add_position` 대칭)
- 음수 인자 전달 시 리스크 상태 역증가 방지

Fixes #78

## 변경 내용
- `src/risk_manager.py`: ValueError 가드 2줄 추가
- `tests/test_risk_manager.py`: 테스트 2건 추가 (28→30개, 100% 커버리지)

## Test plan
- [x] risk_manager 30개 테스트 통과, 100% 커버리지
- [x] 전체 787 테스트 통과, 커버리지 82.80%
- [x] ruff + mypy clean
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)