### PR TITLE
[#86] setup_risk_manager() 3중 복제를 script_helpers로 통합

### DIFF
--- a/scripts/check_positions.py
+++ b/scripts/check_positions.py
@@ -15,17 +15,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-import yaml  # type: ignore[import-untyped]
-
 from src.data_fetcher import DataFetcher
 from src.data_store import ParquetDataStore
 from src.indicators import add_turtle_indicators
 from src.inverse_filter import InverseETFFilter
 from src.market_calendar import get_market_status, infer_market, should_check_signals
 from src.position_tracker import PositionTracker
-from src.risk_manager import PortfolioRiskManager
-from src.script_helpers import load_config, setup_notifier
-from src.types import AssetGroup, Direction, SignalType
+from src.script_helpers import load_config, setup_notifier, setup_risk_manager
+from src.types import Direction, SignalType
 from src.universe_manager import UniverseManager
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -83,47 +80,6 @@ def release_lock(fd):
             fd.close()
         except Exception:
             pass
-
-
-def setup_risk_manager() -> PortfolioRiskManager:
-    """리스크 매니저 설정"""
-    config_path = Path(__file__).parent.parent / "config" / "correlation_groups.yaml"
-    symbol_groups: dict[str, AssetGroup] = {}
-
-    if not config_path.exists():
-        logger.warning(f"상관그룹 설정 파일 없음: {config_path}. 기본 그룹으로 운영합니다.")
-        return PortfolioRiskManager(symbol_groups=symbol_groups)
-
-    try:
-        with open(config_path, "r") as f:
-            config = yaml.safe_load(f)
-
-        if not config or "groups" not in config:
-            logger.warning("상관그룹 설정이 비어있습니다.")
-            return PortfolioRiskManager(symbol_groups=symbol_groups)
-
-        group_mapping = {
-            "kr_equity": AssetGroup.KR_EQUITY,
-            "us_equity": AssetGroup.US_EQUITY,
-            "us_etf": AssetGroup.US_EQUITY,
-            "us_tech": AssetGroup.US_EQUITY,
-            "crypto": AssetGroup.CRYPTO,
-            "commodity": AssetGroup.COMMODITY,
-            "bond": AssetGroup.BOND,
-            "inverse": AssetGroup.INVERSE,
-        }
-
-        for group_name, symbols in config.get("groups", {}).items():
-            asset_group = group_mapping.get(group_name, AssetGroup.US_EQUITY)
-            for symbol in symbols:
-                symbol_groups[symbol] = asset_group
-
-        logger.info(f"상관그룹 설정 로드: {len(symbol_groups)}개 심볼")
-
-    except yaml.YAMLError as e:
-        logger.error(f"상관그룹 YAML 파싱 오류: {e}. 기본 그룹으로 운영합니다.")
-
-    return PortfolioRiskManager(symbol_groups=symbol_groups)
 
 
 def check_stop_loss(position, today_data) -> bool:

--- a/scripts/check_risk_limits.py
+++ b/scripts/check_risk_limits.py
@@ -14,12 +14,6 @@ from pathlib import Path
 from typing import Dict, List
 
 try:
-    import yaml
-except ImportError:
-    yaml = None  # type: ignore[assignment]
-    logging.getLogger(__name__).warning("pyyaml 미설치. YAML 설정 파일을 사용할 수 없습니다.")
-
-try:
     from tabulate import tabulate
 except ImportError:
 
@@ -34,50 +28,10 @@ except ImportError:
 
 from src.position_tracker import Position, PositionTracker
 from src.risk_manager import PortfolioRiskManager, RiskLimits
-from src.script_helpers import load_config
-from src.types import AssetGroup
+from src.script_helpers import load_config, setup_risk_manager
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
-
-
-def setup_risk_manager() -> PortfolioRiskManager:
-    """리스크 매니저 설정"""
-    config_path = Path(__file__).parent.parent / "config" / "correlation_groups.yaml"
-    symbol_groups: dict[str, AssetGroup] = {}
-
-    if not config_path.exists() or yaml is None:
-        logger.warning(f"상관그룹 설정 파일 없음 또는 yaml 미설치: {config_path}. 기본 그룹으로 운영합니다.")
-        return PortfolioRiskManager(symbol_groups=symbol_groups)
-
-    try:
-        with open(config_path, "r") as f:
-            config = yaml.safe_load(f)
-
-        if not config or "groups" not in config:
-            logger.warning("상관그룹 설정이 비어있습니다.")
-            return PortfolioRiskManager(symbol_groups=symbol_groups)
-
-        group_mapping = {
-            "kr_equity": AssetGroup.KR_EQUITY,
-            "us_equity": AssetGroup.US_EQUITY,
-            "us_etf": AssetGroup.US_EQUITY,
-            "crypto": AssetGroup.CRYPTO,
-            "commodity": AssetGroup.COMMODITY,
-            "bond": AssetGroup.BOND,
-        }
-
-        for group_name, symbols in config.get("groups", {}).items():
-            asset_group = group_mapping.get(group_name, AssetGroup.US_EQUITY)
-            for symbol in symbols:
-                symbol_groups[symbol] = asset_group
-
-        logger.info(f"상관그룹 설정 로드: {len(symbol_groups)}개 심볼")
-
-    except yaml.YAMLError as e:
-        logger.error(f"상관그룹 YAML 파싱 오류: {e}. 기본 그룹으로 운영합니다.")
-
-    return PortfolioRiskManager(symbol_groups=symbol_groups)
 
 
 def build_risk_state(positions: List[Position], risk_manager: PortfolioRiskManager) -> Dict:

--- a/scripts/weekly_report.py
+++ b/scripts/weekly_report.py
@@ -15,60 +15,15 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List
 
-try:
-    import yaml
-except ImportError:
-    yaml = None  # type: ignore[assignment]
-    logging.getLogger(__name__).warning("pyyaml 미설치. YAML 설정 파일을 사용할 수 없습니다.")
-
 from src.data_store import ParquetDataStore
 from src.notifier import NotificationLevel, NotificationMessage
 from src.position_tracker import PositionStatus, PositionTracker
 from src.risk_manager import PortfolioRiskManager
-from src.script_helpers import load_config, setup_notifier
-from src.types import AssetGroup
+from src.script_helpers import load_config, setup_notifier, setup_risk_manager
 from src.universe_manager import UniverseManager
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
-
-
-def setup_risk_manager() -> PortfolioRiskManager:
-    """리스크 매니저 설정"""
-    config_path = Path(__file__).parent.parent / "config" / "correlation_groups.yaml"
-    symbol_groups: dict[str, AssetGroup] = {}
-
-    if not config_path.exists() or yaml is None:
-        logger.warning(f"상관그룹 설정 파일 없음 또는 yaml 미설치: {config_path}")
-        return PortfolioRiskManager(symbol_groups=symbol_groups)
-
-    try:
-        with open(config_path, "r") as f:
-            config = yaml.safe_load(f)
-
-        if not config or "groups" not in config:
-            return PortfolioRiskManager(symbol_groups=symbol_groups)
-
-        group_mapping = {
-            "kr_equity": AssetGroup.KR_EQUITY,
-            "us_equity": AssetGroup.US_EQUITY,
-            "us_etf": AssetGroup.US_EQUITY,
-            "crypto": AssetGroup.CRYPTO,
-            "commodity": AssetGroup.COMMODITY,
-            "bond": AssetGroup.BOND,
-        }
-
-        for group_name, symbols in config.get("groups", {}).items():
-            asset_group = group_mapping.get(group_name, AssetGroup.US_EQUITY)
-            for symbol in symbols:
-                symbol_groups[symbol] = asset_group
-
-        logger.info(f"상관그룹 설정 로드: {len(symbol_groups)}개 심볼")
-
-    except yaml.YAMLError as e:
-        logger.error(f"상관그룹 YAML 파싱 오류: {e}")
-
-    return PortfolioRiskManager(symbol_groups=symbol_groups)
 
 
 def get_week_start() -> datetime:

--- a/src/script_helpers.py
+++ b/src/script_helpers.py
@@ -2,11 +2,15 @@
 스크립트 공통 유틸리티 모듈
 - 환경변수 기반 설정 로드
 - 알림 채널 설정
+- 리스크 매니저 통합 설정
 """
 
 import logging
 import os
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml  # type: ignore[import-untyped]
 
 from src.notifier import (
     DiscordChannel,
@@ -14,8 +18,23 @@ from src.notifier import (
     NotificationManager,
     TelegramChannel,
 )
+from src.risk_manager import PortfolioRiskManager
+from src.types import AssetGroup
 
 logger = logging.getLogger(__name__)
+
+# correlation_groups.yaml 그룹명 → AssetGroup 매핑
+# Note: correlation_groups.yaml의 실제 그룹명과 1:1 대응
+_GROUP_MAPPING: dict[str, AssetGroup] = {
+    "us_equity": AssetGroup.US_EQUITY,
+    "us_etf": AssetGroup.US_EQUITY,
+    "us_tech": AssetGroup.US_EQUITY,
+    "kr_equity": AssetGroup.KR_EQUITY,
+    "crypto": AssetGroup.CRYPTO,
+    "commodity": AssetGroup.COMMODITY,
+    "bond": AssetGroup.BOND,
+    "inverse": AssetGroup.INVERSE,
+}
 
 
 def load_config() -> Dict[str, Any]:
@@ -71,3 +90,41 @@ def setup_notifier(config: Dict[str, Any]) -> NotificationManager:
         logger.info("Email 채널 활성화")
 
     return notifier
+
+
+def setup_risk_manager(config_path: Optional[Path] = None) -> PortfolioRiskManager:
+    """correlation_groups.yaml을 로드하여 PortfolioRiskManager 생성.
+
+    모든 스크립트가 동일한 그룹 매핑을 사용하도록 보장.
+    """
+    if config_path is None:
+        config_path = Path(__file__).parent.parent / "config" / "correlation_groups.yaml"
+
+    symbol_groups: dict[str, AssetGroup] = {}
+
+    if not config_path.exists():
+        logger.warning(f"상관그룹 설정 파일 없음: {config_path}. 기본 그룹으로 운영합니다.")
+        return PortfolioRiskManager(symbol_groups=symbol_groups)
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        if not config or "groups" not in config:
+            logger.warning("상관그룹 설정이 비어있습니다.")
+            return PortfolioRiskManager(symbol_groups=symbol_groups)
+
+        for group_name, symbols in config.get("groups", {}).items():
+            asset_group = _GROUP_MAPPING.get(group_name)
+            if asset_group is None:
+                logger.warning(f"Unknown correlation group '{group_name}', defaulting to US_EQUITY")
+                asset_group = AssetGroup.US_EQUITY
+            for symbol in symbols:
+                symbol_groups[symbol] = asset_group
+
+        logger.info(f"상관그룹 설정 로드: {len(symbol_groups)}개 심볼")
+
+    except yaml.YAMLError as e:
+        logger.error(f"상관그룹 YAML 파싱 오류: {e}. 기본 그룹으로 운영합니다.")
+
+    return PortfolioRiskManager(symbol_groups=symbol_groups)

--- a/tests/test_script_helpers.py
+++ b/tests/test_script_helpers.py
@@ -2,9 +2,13 @@
 script_helpers.py 단위 테스트
 """
 
+import logging
+from pathlib import Path
 from unittest.mock import patch
 
-from src.script_helpers import load_config, setup_notifier
+import yaml
+
+from src.script_helpers import _GROUP_MAPPING, load_config, setup_notifier, setup_risk_manager
 
 _NO_DOTENV = patch("dotenv.load_dotenv", lambda *a, **kw: None)
 
@@ -138,3 +142,83 @@ class TestSetupNotifier:
         }
         notifier = setup_notifier(config)
         assert len(notifier.channels) == 1
+
+
+class TestSetupRiskManager:
+    """setup_risk_manager() 통합 버전 테스트"""
+
+    def test_setup_risk_manager_loads_all_groups(self, tmp_path):
+        """YAML에서 모든 그룹이 로드되는지 검증"""
+        yaml_content = {
+            "groups": {
+                "us_equity": ["SPY", "QQQ"],
+                "kr_equity": ["005930.KS"],
+            }
+        }
+        config_path = tmp_path / "test_groups.yaml"
+        config_path.write_text(yaml.dump(yaml_content))
+        rm = setup_risk_manager(config_path=config_path)
+        assert rm is not None
+
+    def test_setup_risk_manager_unknown_group_warns(self, tmp_path, caplog):
+        """미지 그룹명에 warning 로그 발생"""
+        yaml_content = {
+            "groups": {
+                "unknown_group": ["XYZ"],
+            }
+        }
+        config_path = tmp_path / "test_groups.yaml"
+        config_path.write_text(yaml.dump(yaml_content))
+        with caplog.at_level(logging.WARNING):
+            rm = setup_risk_manager(config_path=config_path)
+        assert "Unknown correlation group" in caplog.text
+        assert rm is not None
+
+    def test_all_yaml_groups_have_explicit_mapping(self):
+        """correlation_groups.yaml의 모든 그룹명이 _GROUP_MAPPING에 존재하는지 검증 (regression guard)"""
+        config_path = Path(__file__).parent.parent / "config" / "correlation_groups.yaml"
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+        for group_name in config.get("groups", {}).keys():
+            assert group_name in _GROUP_MAPPING, f"Unmapped group in YAML: {group_name}"
+
+    def test_setup_risk_manager_returns_valid_instance(self):
+        """실제 YAML로 유효한 PortfolioRiskManager 반환 검증"""
+        rm = setup_risk_manager()
+        assert rm is not None
+        assert hasattr(rm, "check_position_limit") or hasattr(rm, "can_add_position")
+
+    def test_setup_risk_manager_missing_file(self, tmp_path, caplog):
+        """존재하지 않는 파일에 대해 빈 매니저 반환"""
+        config_path = tmp_path / "nonexistent.yaml"
+        with caplog.at_level(logging.WARNING):
+            rm = setup_risk_manager(config_path=config_path)
+        assert rm is not None
+        assert "상관그룹 설정 파일 없음" in caplog.text
+
+    def test_setup_risk_manager_empty_config(self, tmp_path, caplog):
+        """groups 키가 없는 YAML에 대해 빈 매니저 반환"""
+        config_path = tmp_path / "empty.yaml"
+        config_path.write_text(yaml.dump({"other_key": "value"}))
+        with caplog.at_level(logging.WARNING):
+            rm = setup_risk_manager(config_path=config_path)
+        assert rm is not None
+        assert "상관그룹 설정이 비어있습니다" in caplog.text
+
+    def test_symbol_group_assignment(self, tmp_path):
+        """심볼별 그룹 할당이 올바른지 검증"""
+        from src.types import AssetGroup
+
+        yaml_content = {
+            "groups": {
+                "us_equity": ["SPY"],
+                "crypto": ["BTC"],
+                "inverse": ["SH"],
+            }
+        }
+        config_path = tmp_path / "test_groups.yaml"
+        config_path.write_text(yaml.dump(yaml_content))
+        rm = setup_risk_manager(config_path=config_path)
+        assert rm.get_group("SPY") == AssetGroup.US_EQUITY
+        assert rm.get_group("BTC") == AssetGroup.CRYPTO
+        assert rm.get_group("SH") == AssetGroup.INVERSE


### PR DESCRIPTION
## Summary

- `src/script_helpers.py`에 통합 `setup_risk_manager()` 추가
- `_GROUP_MAPPING`: `correlation_groups.yaml`의 7개 그룹 명시적 매핑
- `check_positions.py`, `check_risk_limits.py`, `weekly_report.py`의 로컬 구현 제거
- `us_tech`/`inverse` 그룹 누락으로 인한 리스크 그룹 오분류 해결
- 테스트 7개 추가 (regression guard 포함)

## Test plan

- [x] `test_setup_risk_manager_loads_all_groups` — YAML 그룹 로드 검증
- [x] `test_setup_risk_manager_unknown_group_warns` — 미지 그룹 warning 검증
- [x] `test_all_yaml_groups_have_explicit_mapping` — 매핑 완전성 regression guard
- [x] `test_setup_risk_manager_returns_valid_instance` — 실제 YAML 유효성
- [x] `test_setup_risk_manager_missing_file` — 설정 파일 누락 처리
- [x] `test_setup_risk_manager_empty_config` — 빈 YAML 처리
- [x] `test_symbol_group_assignment` — 심볼별 AssetGroup 배정 검증

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)