### PR TITLE
[#95] 테스트 품질 패치: false-positive 제거 및 커버리지 보강

### DIFF
--- a/tests/test_check_positions.py
+++ b/tests/test_check_positions.py
@@ -24,7 +24,6 @@ import os
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
-import yaml
 from conftest import PatchManager
 
 from scripts.check_positions import (
@@ -1177,75 +1176,14 @@ class TestSetupNotifier:
 
 
 class TestSetupRiskManager:
-    """setup_risk_manager() 리스크 매니저 설정 테스트."""
+    """setup_risk_manager() 리스크 매니저 설정 테스트.
+
+    에러 핸들링/엣지 케이스 테스트는 test_script_helpers.py::TestSetupRiskManager 참조.
+    """
 
     def test_loads_real_config(self):
         """실제 config/correlation_groups.yaml 로 정상 로드."""
         rm = setup_risk_manager()
-        assert rm is not None
-
-    def test_missing_file(self, tmp_path):
-        """설정 파일 없음 -> 기본 그룹 운영."""
-        fake_config = tmp_path / "correlation_groups.yaml"
-        with patch("scripts.check_positions.Path") as MockPath:
-            # __file__ 경로 체인: Path(__file__).parent.parent / "config" / "correlation_groups.yaml"
-            mock_file_path = MagicMock()
-            MockPath.return_value = mock_file_path
-            mock_file_path.parent.parent.__truediv__.return_value.__truediv__.return_value = fake_config
-            rm = setup_risk_manager()
-        assert rm is not None
-
-    def test_empty_config(self, tmp_path):
-        """YAML이 비어 있으면 기본 그룹 운영."""
-        fake_config = tmp_path / "correlation_groups.yaml"
-        fake_config.write_text("")
-        with patch("scripts.check_positions.Path") as MockPath:
-            mock_file_path = MagicMock()
-            MockPath.return_value = mock_file_path
-            mock_file_path.parent.parent.__truediv__.return_value.__truediv__.return_value = fake_config
-            rm = setup_risk_manager()
-        assert rm is not None
-
-    def test_config_no_groups_key(self, tmp_path):
-        """YAML에 groups 키 없으면 기본 그룹 운영."""
-        fake_config = tmp_path / "correlation_groups.yaml"
-        fake_config.write_text("other_key: value\n")
-        with patch("scripts.check_positions.Path") as MockPath:
-            mock_file_path = MagicMock()
-            MockPath.return_value = mock_file_path
-            mock_file_path.parent.parent.__truediv__.return_value.__truediv__.return_value = fake_config
-            rm = setup_risk_manager()
-        assert rm is not None
-
-    def test_yaml_error(self, tmp_path):
-        """YAML 파싱 오류 -> 기본 그룹 운영."""
-        fake_config = tmp_path / "correlation_groups.yaml"
-        fake_config.write_text("invalid: yaml: [\n")
-        with patch("scripts.check_positions.Path") as MockPath:
-            mock_file_path = MagicMock()
-            MockPath.return_value = mock_file_path
-            mock_file_path.parent.parent.__truediv__.return_value.__truediv__.return_value = fake_config
-            rm = setup_risk_manager()
-        assert rm is not None
-
-    def test_valid_groups_parsed(self, tmp_path):
-        """정상 그룹 설정이 파싱되어 심볼이 매핑됨."""
-        fake_config = tmp_path / "correlation_groups.yaml"
-        fake_config.write_text(
-            yaml.dump(
-                {
-                    "groups": {
-                        "us_equity": ["SPY", "QQQ"],
-                        "crypto": ["BTC-USD"],
-                    }
-                }
-            )
-        )
-        with patch("scripts.check_positions.Path") as MockPath:
-            mock_file_path = MagicMock()
-            MockPath.return_value = mock_file_path
-            mock_file_path.parent.parent.__truediv__.return_value.__truediv__.return_value = fake_config
-            rm = setup_risk_manager()
         assert rm is not None
 
 
@@ -2373,3 +2311,18 @@ class TestSaveTradeIntegration:
         assert tracker.close_position.call_count == 2
         # save_trade도 두 번 시도되어야 함
         assert ds.save_trade.call_count == 2
+
+    async def test_close_position_none_skips_save_trade(self):
+        """close_position()이 None 반환 시 save_trade 호출 안 됨."""
+        pos = _make_open_position(symbol="SPY", stop_loss=98.0)
+        patches, notifier, tracker, rm, fetcher, ds = self._build_patches(
+            open_positions=[pos],
+            fetch_df=self._make_mock_df(high=100, low=95, close=96),
+        )
+        tracker.close_position.return_value = None
+        PatchManager.start_all(patches)
+        try:
+            await _run_checks()
+        finally:
+            PatchManager.stop_all(patches)
+        ds.save_trade.assert_not_called()

--- a/tests/test_script_helpers.py
+++ b/tests/test_script_helpers.py
@@ -222,3 +222,12 @@ class TestSetupRiskManager:
         assert rm.get_group("SPY") == AssetGroup.US_EQUITY
         assert rm.get_group("BTC") == AssetGroup.CRYPTO
         assert rm.get_group("SH") == AssetGroup.INVERSE
+
+    def test_setup_risk_manager_malformed_yaml(self, tmp_path, caplog):
+        """YAML 파싱 오류 시 에러 로그 + 빈 매니저 반환"""
+        config_path = tmp_path / "malformed.yaml"
+        config_path.write_text("invalid: yaml: [\n")
+        with caplog.at_level(logging.ERROR):
+            rm = setup_risk_manager(config_path=config_path)
+        assert rm is not None
+        assert "YAML 파싱 오류" in caplog.text


### PR DESCRIPTION
## Summary
- Agent Council v3.5.0 리뷰에서 발견된 테스트 품질 이슈 3건 수정
- **P0**: `TestSetupRiskManager` (test_check_positions.py) false-positive 5건 삭제 — 패치 대상 모듈 불일치로 무효화된 테스트
- **P1**: `TestSetupRiskManager` (test_script_helpers.py) YAMLError 핸들러 테스트 추가
- **P2**: `TestSaveTradeIntegration` close_position() → None 시 save_trade 미호출 테스트 추가
- 미사용 `yaml` import 정리

## Changes
| 파일 | 변경 | 테스트 수 |
|------|------|-----------|
| `tests/test_check_positions.py` | false-positive 5건 삭제, None guard 테스트 추가, yaml import 제거 | -5, +1 |
| `tests/test_script_helpers.py` | YAMLError 테스트 추가 | +1 |
| **합계** | | 803 → 800 |

## Test plan
- [x] 800 tests passing
- [x] TestSetupRiskManager: 1건만 남은 것 확인
- [x] test_setup_risk_manager_malformed_yaml: YAML 파싱 오류 로그 검증
- [x] test_close_position_none_skips_save_trade: save_trade 미호출 검증

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)