### PR TITLE
[#107] enforce-branch-policy 훅에 태그 push 예외 추가

### DIFF
--- a/.claude/hooks/enforce-branch-policy.sh
+++ b/.claude/hooks/enforce-branch-policy.sh
@@ -48,10 +48,16 @@ fi
 
 # 5. main에서 git push (브랜치 미명시 포함) 전면 차단
 #    rev.2 ISSUE 4: git push origin, git push, git push -u origin 등 모두 커버
+#    rev.5: 태그 push는 예외 허용 (refs/tags/ 패턴)
 if echo "$COMMAND" | grep -qE '\bgit\s+push\b'; then
   if [ "$BRANCH" = "main" ]; then
+    # 태그 push는 코드 변경 없이 기존 커밋에 레이블만 부착하므로 허용
+    if echo "$COMMAND" | grep -qE '\bgit\s+push\b.*\brefs/tags/'; then
+      exit 0
+    fi
     echo "BLOCKED: main 브랜치에서 push 금지. feature 브랜치에서 작업하세요." >&2
     echo "허용: git push origin feature/issue-NNN-<설명>" >&2
+    echo "허용: git push origin refs/tags/<태그명> (태그 push)" >&2
     exit 2
   fi
 fi


### PR DESCRIPTION
## Summary

- `enforce-branch-policy.sh` Rule #5에 `refs/tags/` 패턴 예외 추가
- 태그 push가 차단되던 버그 수정

## 배경

v3.6.0 태그 push 시 발견. 태그 push는 기존 커밋에 레이블을 붙이는 것으로, 브랜치 push와 달리 코드 변경이 없으며 Branch Protection 대상도 아님.

## 변경 내용

Rule #5에 `refs/tags/` 패턴 감지 추가:
- `git push origin refs/tags/v3.6.0` → 허용 (태그)
- 브랜치 push from 보호 브랜치 → 여전히 차단

차단 메시지에 태그 push 허용 안내 추가.

## Test plan

- [x] `refs/tags/` 포함 명령은 exit 0 (허용)
- [x] `refs/tags/` 미포함 push는 exit 2 (차단)
- [x] 기존 Rule 1-4 동작 불변

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
