### PR TITLE
[#119] scripts/README.md 킬 스위치 깨진 앵커 링크 수정

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -259,7 +259,7 @@ python scripts/toggle_trading.py --status
 ##### Notes
 
 - State is persisted in `config/system_status.yaml` via `KillSwitch` class in `src/kill_switch.py`
-- See [킬 스위치 (Kill Switch)](../docs/operations-guide.md#킬-스위치-kill-switch) for detailed behavior and fail-open policy
+- Kill switch behavior and fail-open policy는 PR #110 머지 후 [운영 가이드](../docs/operations-guide.md)에 추가 예정
 
 ---
 


### PR DESCRIPTION
## Summary
- `scripts/README.md:262`의 `operations-guide.md#킬-스위치-kill-switch` 앵커가 현재 main에 존재하지 않아 깨진 링크 발생
- PR #110 (kill switch) 머지 전까지는 해당 섹션이 없으므로, 의존성을 명시하는 텍스트로 교체

Fixes #119

## Test plan
- [x] 깨진 앵커 링크가 제거되었는지 확인
- [x] PR #110 의존성 안내 문구가 명확한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)