### PR TITLE
[#144] Paper Trading 모드 확장 (슬리피지 포함)

### DIFF
--- a/scripts/paper_trade_report.py
+++ b/scripts/paper_trade_report.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Paper Trading 성과 리포트 생성 스크립트.
+
+data/paper_trading/ 의 거래 기록을 읽어 성과 지표를 출력한다.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+from src.utils import safe_load_json
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PAPER_TRADING_DIR = Path(__file__).parent.parent / "data" / "paper_trading"
+PORTFOLIO_PATH = PAPER_TRADING_DIR / "portfolio.json"
+TRADES_PATH = PAPER_TRADING_DIR / "trades.json"
+
+
+def _calc_mdd(equity_curve: list[float]) -> float:
+    """최대 낙폭(MDD) 계산"""
+    if not equity_curve:
+        return 0.0
+    peak = equity_curve[0]
+    max_dd = 0.0
+    for value in equity_curve:
+        if value > peak:
+            peak = value
+        drawdown = (peak - value) / peak if peak > 0 else 0.0
+        if drawdown > max_dd:
+            max_dd = drawdown
+    return max_dd
+
+
+def generate_report(initial_capital: float = 5_000_000) -> dict:
+    """Paper trading 성과 리포트 데이터 생성"""
+    portfolio = safe_load_json(PORTFOLIO_PATH, default={})
+    trades: list[dict] = safe_load_json(TRADES_PATH, default=[])
+
+    if not portfolio and not trades:
+        logger.warning("Paper trading 데이터가 없습니다. 먼저 dry-run 매매를 실행하세요.")
+        return {}
+
+    cash = portfolio.get("cash", initial_capital)
+    positions = portfolio.get("positions", {})
+
+    # 포지션 현재가치 (avg_price 기반 추정)
+    position_value = sum(p.get("quantity", 0) * p.get("avg_price", 0) for p in positions.values())
+    total_equity = cash + position_value
+    total_pnl = total_equity - initial_capital
+    return_pct = (total_pnl / initial_capital * 100) if initial_capital > 0 else 0.0
+
+    # 거래 통계
+    closed_trades = [t for t in trades if t.get("side") == "sell"]
+    winning = [t for t in closed_trades if t.get("pnl", 0) > 0]
+    losing = [t for t in closed_trades if t.get("pnl", 0) <= 0]
+    win_rate = len(winning) / len(closed_trades) * 100 if closed_trades else 0.0
+
+    avg_win = sum(t["pnl"] for t in winning) / len(winning) if winning else 0.0
+    avg_loss = sum(abs(t["pnl"]) for t in losing) / len(losing) if losing else 0.0
+    profit_factor = avg_win / avg_loss if avg_loss > 0 else float("inf")
+
+    # 슬리피지 / 수수료 누적
+    total_slippage_cost = sum(abs(t.get("slippage", 0)) * t.get("quantity", 0) for t in trades)
+    total_commission = sum(t.get("commission", 0) for t in trades)
+
+    # MDD: 거래별 누적 pnl 기반 equity curve 근사
+    equity_curve: list[float] = [initial_capital]
+    running = initial_capital
+    for t in trades:
+        running += t.get("pnl", 0) - t.get("commission", 0)
+        equity_curve.append(running)
+    mdd = _calc_mdd(equity_curve)
+
+    return {
+        "total_trades": len(trades),
+        "closed_trades": len(closed_trades),
+        "winning_trades": len(winning),
+        "losing_trades": len(losing),
+        "win_rate_pct": win_rate,
+        "profit_factor": profit_factor,
+        "total_pnl": total_pnl,
+        "return_pct": return_pct,
+        "mdd_pct": mdd * 100,
+        "total_slippage_cost": total_slippage_cost,
+        "total_commission": total_commission,
+        "cash": cash,
+        "position_value": position_value,
+        "total_equity": total_equity,
+        "open_positions": len(positions),
+    }
+
+
+def print_report(report: dict, initial_capital: float) -> None:
+    """리포트 콘솔 출력"""
+    sep = "=" * 55
+    print(sep)
+    print("  Paper Trading 성과 리포트")
+    print(sep)
+    print(f"  초기 자본      : {initial_capital:>15,.0f} 원")
+    print(f"  현재 자산      : {report['total_equity']:>15,.0f} 원")
+    print(f"  총 손익        : {report['total_pnl']:>+15,.0f} 원")
+    print(f"  수익률         : {report['return_pct']:>14.2f} %")
+    print(f"  최대낙폭(MDD)  : {report['mdd_pct']:>14.2f} %")
+    print(sep)
+    print(f"  총 주문        : {report['total_trades']:>15,} 건")
+    print(f"  청산 거래      : {report['closed_trades']:>15,} 건")
+    print(f"  승률           : {report['win_rate_pct']:>14.1f} %")
+    print(f"  손익비(PF)     : {report['profit_factor']:>15.2f}")
+    print(sep)
+    print(f"  누적 슬리피지  : {report['total_slippage_cost']:>15,.0f} 원")
+    print(f"  누적 수수료    : {report['total_commission']:>15,.0f} 원")
+    print(f"  오픈 포지션    : {report['open_positions']:>15,} 개")
+    print(sep)
+    print()
+    print("  [실거래 전환 판단 기준 안내]")
+    print("  - 수익률 > 0%, MDD < 20%, 승률 >= 40%, 손익비 >= 1.5")
+    print("  - 슬리피지 + 수수료 합계가 총수익의 20% 이하")
+    print("  - 최소 30건 이상의 청산 거래 확보")
+    print(sep)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Paper Trading 성과 리포트")
+    parser.add_argument(
+        "--capital",
+        type=float,
+        default=5_000_000,
+        help="초기 자본 (기본: 5,000,000원)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="JSON 형식으로 출력",
+    )
+    args = parser.parse_args()
+
+    logger.info("=== Paper Trading 리포트 생성 시작 ===")
+    report = generate_report(initial_capital=args.capital)
+
+    if not report:
+        return
+
+    if args.json:
+        import json
+
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print_report(report, initial_capital=args.capital)
+
+    logger.info("=== 리포트 완료 ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/auto_trader.py
+++ b/src/auto_trader.py
@@ -12,7 +12,7 @@ import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from src.kill_switch import KillSwitch
 from src.kis_api import KISAPIClient, OrderSide, OrderType
@@ -20,6 +20,9 @@ from src.notifier import NotificationLevel, NotificationManager, NotificationMes
 from src.types import OrderStatus
 from src.utils import atomic_write_json, safe_load_json
 from src.vi_cb_detector import VICBDetector
+
+if TYPE_CHECKING:
+    from src.paper_trader import PaperPortfolio
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +71,7 @@ class AutoTrader:
         reconfirm_delay_sec: float = DEFAULT_RECONFIRM_DELAY_SEC,
         kill_switch: Optional["KillSwitch"] = None,
         vi_cb_detector: Optional["VICBDetector"] = None,
+        paper_portfolio: Optional["PaperPortfolio"] = None,
     ):
         self.kis_client = kis_client
         self.dry_run = dry_run
@@ -76,6 +80,7 @@ class AutoTrader:
         self.reconfirm_delay_sec = reconfirm_delay_sec
         self.kill_switch = kill_switch
         self.vi_cb_detector = vi_cb_detector
+        self.paper_portfolio = paper_portfolio
         self._order_counter = 0
 
         if not dry_run:
@@ -227,6 +232,15 @@ class AutoTrader:
                 fill_time=timestamp,
                 reason=reason,
             )
+            if self.paper_portfolio:
+                paper_record = self.paper_portfolio.execute_paper_order(
+                    order_id=order_id,
+                    symbol=symbol,
+                    side=side.value,
+                    quantity=quantity,
+                    requested_price=price,
+                )
+                record.fill_price = paper_record.fill_price  # 슬리피지 적용 가격으로 업데이트
             self._append_order_to_log(record)
             return record
 

--- a/src/paper_trader.py
+++ b/src/paper_trader.py
@@ -1,0 +1,168 @@
+"""Paper Trading 포트폴리오 매니저 — 슬리피지 포함 가상 체결."""
+
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from src.utils import atomic_write_json, safe_load_json
+
+logger = logging.getLogger(__name__)
+
+PAPER_TRADING_DIR = Path(__file__).parent.parent / "data" / "paper_trading"
+PORTFOLIO_PATH = PAPER_TRADING_DIR / "portfolio.json"
+TRADES_PATH = PAPER_TRADING_DIR / "trades.json"
+
+
+@dataclass
+class PaperPosition:
+    symbol: str
+    side: str  # "buy" or "sell"
+    quantity: int
+    avg_price: float
+    unrealized_pnl: float = 0.0
+
+
+@dataclass
+class PaperTradeRecord:
+    order_id: str
+    symbol: str
+    side: str
+    quantity: int
+    requested_price: float
+    fill_price: float
+    slippage: float
+    commission: float
+    timestamp: str = ""
+    pnl: float = 0.0  # for closing trades
+
+
+class PaperPortfolio:
+    """가상 포트폴리오 — dry_run 주문을 슬리피지 적용하여 추적.
+
+    고정 비율 슬리피지 모델 한계 인지. v4.0에서 변동 슬리피지 모델 검토."""
+
+    def __init__(
+        self,
+        initial_capital: float = 5_000_000,
+        slippage_pct: Optional[float] = None,
+        commission_pct: float = 0.001,  # backtester.py와 동일
+    ):
+        self.initial_capital = initial_capital
+        self.slippage_pct = (
+            slippage_pct if slippage_pct is not None else float(os.environ.get("PAPER_SLIPPAGE_PCT", "0.0005"))
+        )
+        self.commission_pct = commission_pct
+
+        PAPER_TRADING_DIR.mkdir(parents=True, exist_ok=True)
+
+        self.cash = initial_capital
+        self.positions: dict[str, PaperPosition] = {}
+        self.trades: list[dict] = []
+        self._load_state()
+
+    def _load_state(self) -> None:
+        """기존 포트폴리오 상태 로드"""
+        portfolio = safe_load_json(PORTFOLIO_PATH, default={})
+        if portfolio:
+            self.cash = portfolio.get("cash", self.initial_capital)
+            for sym, pos_data in portfolio.get("positions", {}).items():
+                self.positions[sym] = PaperPosition(**pos_data)
+
+        self.trades = safe_load_json(TRADES_PATH, default=[])
+
+    def _save_state(self) -> None:
+        """포트폴리오 상태 저장"""
+        portfolio_data = {
+            "cash": self.cash,
+            "positions": {sym: asdict(pos) for sym, pos in self.positions.items()},
+            "last_updated": datetime.now().isoformat(),
+        }
+        atomic_write_json(PORTFOLIO_PATH, portfolio_data)
+        atomic_write_json(TRADES_PATH, self.trades)
+
+    def _simulate_fill_price(self, requested_price: float, side: str) -> float:
+        """슬리피지 시뮬레이션 — 시장 마찰 반영.
+
+        BUY: 약간 높은 가격에 체결 (불리), SELL: 약간 낮은 가격에 체결 (불리)"""
+        if side == "buy":
+            return requested_price * (1 + self.slippage_pct)
+        else:
+            return requested_price * (1 - self.slippage_pct)
+
+    def execute_paper_order(
+        self,
+        order_id: str,
+        symbol: str,
+        side: str,
+        quantity: int,
+        requested_price: float,
+    ) -> PaperTradeRecord:
+        """가상 주문 실행 — 슬리피지 + 수수료 적용"""
+        fill_price = self._simulate_fill_price(requested_price, side)
+        slippage = fill_price - requested_price
+        trade_amount = fill_price * quantity
+        commission = trade_amount * self.commission_pct
+        pnl = 0.0
+
+        if side == "buy":
+            self.cash -= trade_amount + commission
+            if symbol in self.positions:
+                pos = self.positions[symbol]
+                total_qty = pos.quantity + quantity
+                pos.avg_price = ((pos.avg_price * pos.quantity) + (fill_price * quantity)) / total_qty
+                pos.quantity = total_qty
+            else:
+                self.positions[symbol] = PaperPosition(
+                    symbol=symbol,
+                    side="buy",
+                    quantity=quantity,
+                    avg_price=fill_price,
+                )
+        else:  # sell
+            self.cash += trade_amount - commission
+            if symbol in self.positions:
+                pos = self.positions[symbol]
+                pnl = (fill_price - pos.avg_price) * quantity
+                pos.quantity -= quantity
+                if pos.quantity <= 0:
+                    del self.positions[symbol]
+
+        record = PaperTradeRecord(
+            order_id=order_id,
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            requested_price=requested_price,
+            fill_price=fill_price,
+            slippage=slippage,
+            commission=commission,
+            timestamp=datetime.now().isoformat(),
+            pnl=pnl,
+        )
+        self.trades.append(asdict(record))
+        self._save_state()
+        logger.info(
+            f"[PAPER] {side.upper()} {symbol} {quantity}주 @ {fill_price:,.0f}원 "
+            f"(슬리피지 {slippage:+,.0f}원, 수수료 {commission:,.0f}원)"
+        )
+        return record
+
+    def get_portfolio_snapshot(self) -> dict:
+        """현재 포트폴리오 스냅샷"""
+        total_position_value = sum(pos.quantity * pos.avg_price for pos in self.positions.values())
+        total_equity = self.cash + total_position_value
+        total_pnl = total_equity - self.initial_capital
+        return {
+            "cash": self.cash,
+            "positions": {sym: asdict(pos) for sym, pos in self.positions.items()},
+            "total_position_value": total_position_value,
+            "total_equity": total_equity,
+            "total_pnl": total_pnl,
+            "return_pct": (total_pnl / self.initial_capital) * 100 if self.initial_capital > 0 else 0,
+            "trade_count": len(self.trades),
+            "total_slippage": sum(abs(t.get("slippage", 0) * t.get("quantity", 0)) for t in self.trades),
+            "total_commission": sum(t.get("commission", 0) for t in self.trades),
+        }

--- a/tests/test_paper_trader.py
+++ b/tests/test_paper_trader.py
@@ -1,0 +1,216 @@
+"""
+paper_trader.py 단위 테스트
+- 매수/매도 주문 실행
+- 슬리피지 방향 검증
+- 수수료 공제 검증
+- 피라미딩 평균 단가 계산
+- 포트폴리오 스냅샷
+- 상태 영속성 (저장/로드)
+- PAPER_SLIPPAGE_PCT 환경변수 오버라이드
+"""
+
+import pytest
+
+from src.paper_trader import PaperPortfolio
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def portfolio(tmp_path, monkeypatch):
+    """임시 디렉터리를 사용하는 PaperPortfolio (상태 격리)"""
+    paper_dir = tmp_path / "paper_trading"
+    monkeypatch.setattr("src.paper_trader.PAPER_TRADING_DIR", paper_dir)
+    monkeypatch.setattr("src.paper_trader.PORTFOLIO_PATH", paper_dir / "portfolio.json")
+    monkeypatch.setattr("src.paper_trader.TRADES_PATH", paper_dir / "trades.json")
+    return PaperPortfolio(
+        initial_capital=10_000_000,
+        slippage_pct=0.001,
+        commission_pct=0.001,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 매수 주문
+# ---------------------------------------------------------------------------
+
+
+def test_execute_buy_order(portfolio):
+    """매수 주문 후 현금이 줄고 포지션이 생성된다."""
+    initial_cash = portfolio.cash
+    record = portfolio.execute_paper_order(
+        order_id="TEST_001",
+        symbol="005930",
+        side="buy",
+        quantity=10,
+        requested_price=70_000,
+    )
+    assert record.side == "buy"
+    assert record.quantity == 10
+    assert "005930" in portfolio.positions
+    pos = portfolio.positions["005930"]
+    assert pos.quantity == 10
+    # 슬리피지가 적용된 fill_price로 체결
+    expected_fill = 70_000 * (1 + 0.001)
+    expected_cost = expected_fill * 10 * (1 + 0.001)
+    assert portfolio.cash == pytest.approx(initial_cash - expected_cost, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 매도 주문 (청산)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_sell_order(portfolio):
+    """매수 후 매도하면 포지션이 청산되고 PnL이 기록된다."""
+    portfolio.execute_paper_order("BUY_001", "000660", "buy", 5, 100_000)
+    assert "000660" in portfolio.positions
+
+    record = portfolio.execute_paper_order("SELL_001", "000660", "sell", 5, 110_000)
+    assert record.side == "sell"
+    assert record.pnl != 0.0
+    assert "000660" not in portfolio.positions
+
+
+# ---------------------------------------------------------------------------
+# 슬리피지 방향
+# ---------------------------------------------------------------------------
+
+
+def test_slippage_buy_higher(portfolio):
+    """BUY 체결가는 요청가보다 높아야 한다."""
+    record = portfolio.execute_paper_order("S1", "005930", "buy", 1, 50_000)
+    assert record.fill_price > record.requested_price
+
+
+def test_slippage_sell_lower(portfolio):
+    """SELL 체결가는 요청가보다 낮아야 한다."""
+    # 먼저 매수
+    portfolio.execute_paper_order("B1", "005930", "buy", 1, 50_000)
+    record = portfolio.execute_paper_order("S1", "005930", "sell", 1, 50_000)
+    assert record.fill_price < record.requested_price
+
+
+def test_slippage_zero(tmp_path, monkeypatch):
+    """slippage_pct=0 이면 fill_price == requested_price"""
+    paper_dir = tmp_path / "paper_trading_zero"
+    monkeypatch.setattr("src.paper_trader.PAPER_TRADING_DIR", paper_dir)
+    monkeypatch.setattr("src.paper_trader.PORTFOLIO_PATH", paper_dir / "portfolio.json")
+    monkeypatch.setattr("src.paper_trader.TRADES_PATH", paper_dir / "trades.json")
+    p = PaperPortfolio(initial_capital=1_000_000, slippage_pct=0.0, commission_pct=0.0)
+    record = p.execute_paper_order("Z1", "TEST", "buy", 1, 10_000)
+    assert record.fill_price == pytest.approx(10_000.0)
+    assert record.slippage == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# 수수료
+# ---------------------------------------------------------------------------
+
+
+def test_commission_deducted(tmp_path, monkeypatch):
+    """commission_pct > 0 이면 현금이 추가로 감소한다."""
+    paper_dir = tmp_path / "paper_comm"
+    monkeypatch.setattr("src.paper_trader.PAPER_TRADING_DIR", paper_dir)
+    monkeypatch.setattr("src.paper_trader.PORTFOLIO_PATH", paper_dir / "portfolio.json")
+    monkeypatch.setattr("src.paper_trader.TRADES_PATH", paper_dir / "trades.json")
+    # slippage_pct=0 으로 고정, commission만 확인
+    p = PaperPortfolio(initial_capital=1_000_000, slippage_pct=0.0, commission_pct=0.001)
+    initial_cash = p.cash
+    record = p.execute_paper_order("C1", "TEST", "buy", 10, 10_000)
+    expected_commission = 10_000 * 10 * 0.001
+    assert record.commission == pytest.approx(expected_commission, rel=1e-6)
+    # 현금 = initial - (fill_price * qty) - commission
+    expected_cash = initial_cash - (10_000 * 10) - expected_commission
+    assert p.cash == pytest.approx(expected_cash, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 피라미딩 평균 단가
+# ---------------------------------------------------------------------------
+
+
+def test_pyramid_buy_avg_price(portfolio):
+    """동일 종목 여러 번 매수 시 평균 단가가 올바르게 계산된다."""
+    portfolio.execute_paper_order("B1", "035420", "buy", 10, 100_000)
+    portfolio.execute_paper_order("B2", "035420", "buy", 10, 120_000)
+
+    pos = portfolio.positions["035420"]
+    assert pos.quantity == 20
+    # fill_price = requested * (1 + slippage)
+    fp1 = 100_000 * 1.001
+    fp2 = 120_000 * 1.001
+    expected_avg = (fp1 * 10 + fp2 * 10) / 20
+    assert pos.avg_price == pytest.approx(expected_avg, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 포트폴리오 스냅샷
+# ---------------------------------------------------------------------------
+
+
+def test_portfolio_snapshot(portfolio):
+    """스냅샷이 정확한 필드와 값을 반환한다."""
+    portfolio.execute_paper_order("B1", "005930", "buy", 5, 70_000)
+    snap = portfolio.get_portfolio_snapshot()
+
+    assert "cash" in snap
+    assert "total_equity" in snap
+    assert "total_pnl" in snap
+    assert "return_pct" in snap
+    assert "trade_count" in snap
+    assert "total_slippage" in snap
+    assert "total_commission" in snap
+    assert snap["trade_count"] == 1
+    assert snap["total_commission"] > 0
+    # total_equity = cash + position_value
+    assert snap["total_equity"] == pytest.approx(snap["cash"] + snap["total_position_value"], rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 영속성 (저장/로드)
+# ---------------------------------------------------------------------------
+
+
+def test_portfolio_persistence(tmp_path, monkeypatch):
+    """저장 후 새 인스턴스에서 로드해도 상태가 유지된다."""
+    paper_dir = tmp_path / "paper_persist"
+    monkeypatch.setattr("src.paper_trader.PAPER_TRADING_DIR", paper_dir)
+    portfolio_path = paper_dir / "portfolio.json"
+    trades_path = paper_dir / "trades.json"
+    monkeypatch.setattr("src.paper_trader.PORTFOLIO_PATH", portfolio_path)
+    monkeypatch.setattr("src.paper_trader.TRADES_PATH", trades_path)
+
+    p1 = PaperPortfolio(initial_capital=5_000_000, slippage_pct=0.0, commission_pct=0.0)
+    p1.execute_paper_order("B1", "005930", "buy", 3, 80_000)
+    saved_cash = p1.cash
+    saved_qty = p1.positions["005930"].quantity
+
+    # 새 인스턴스 생성 — 같은 경로에서 로드
+    p2 = PaperPortfolio(initial_capital=5_000_000, slippage_pct=0.0, commission_pct=0.0)
+    assert p2.cash == pytest.approx(saved_cash, rel=1e-6)
+    assert "005930" in p2.positions
+    assert p2.positions["005930"].quantity == saved_qty
+    assert len(p2.trades) == 1
+
+
+# ---------------------------------------------------------------------------
+# 환경변수 슬리피지 오버라이드
+# ---------------------------------------------------------------------------
+
+
+def test_env_slippage_override(tmp_path, monkeypatch):
+    """PAPER_SLIPPAGE_PCT 환경변수가 slippage_pct를 덮어쓴다."""
+    paper_dir = tmp_path / "paper_env"
+    monkeypatch.setattr("src.paper_trader.PAPER_TRADING_DIR", paper_dir)
+    monkeypatch.setattr("src.paper_trader.PORTFOLIO_PATH", paper_dir / "portfolio.json")
+    monkeypatch.setattr("src.paper_trader.TRADES_PATH", paper_dir / "trades.json")
+    monkeypatch.setenv("PAPER_SLIPPAGE_PCT", "0.002")
+
+    # slippage_pct=None → 환경변수에서 읽음
+    p = PaperPortfolio(initial_capital=1_000_000, slippage_pct=None, commission_pct=0.0)
+    assert p.slippage_pct == pytest.approx(0.002)
+    record = p.execute_paper_order("E1", "TEST", "buy", 1, 10_000)
+    assert record.fill_price == pytest.approx(10_000 * 1.002)


### PR DESCRIPTION
## Summary
- PaperPortfolio: 가상 잔고/포지션 추적 + 슬리피지 시뮬레이션 (기본 0.05%)
- dry_run 모드에서 PaperPortfolio.execute_paper_order() 자동 호출
- Paper Trading 성과 리포트 스크립트 (수익률, MDD, 승률, PF)

## Files Changed
- `src/paper_trader.py` (NEW) — PaperPortfolio + PaperPosition + PaperTradeRecord
- `src/auto_trader.py` — dry_run PaperPortfolio 연동
- `scripts/paper_trade_report.py` (NEW) — 성과 리포트 CLI
- `tests/test_paper_trader.py` (NEW) — 10 tests

## Test plan
- [x] `pytest tests/test_paper_trader.py -v` — 10 tests passed
- [x] Full suite regression check

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)