### PR TITLE
[#170] fix: Docker 실행 경로 알림 누락 및 NotificationManager no-op 수정

### DIFF
--- a/scripts/fetch_universe_charts.py
+++ b/scripts/fetch_universe_charts.py
@@ -7,6 +7,7 @@
 """
 
 import argparse
+import asyncio
 import logging
 import sys
 from datetime import datetime
@@ -17,6 +18,8 @@ PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.append(str(PROJECT_ROOT))
 
 from src.local_chart_renderer import BatchChartRenderer  # noqa: E402
+from src.notifier import NotificationLevel, NotificationMessage  # noqa: E402
+from src.script_helpers import load_config, setup_notifier  # noqa: E402
 from src.universe_manager import UniverseManager  # noqa: E402
 
 logging.basicConfig(
@@ -25,6 +28,20 @@ logging.basicConfig(
     handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger("ChartBatch")
+
+
+def _send_notification(title: str, body: str, level: NotificationLevel):
+    """설정된 채널(Telegram/Discord/Email)로 알림을 발송한다."""
+    try:
+        config = load_config()
+        notifier = setup_notifier(config)
+        if not notifier.channels:
+            logger.info("알림 채널 미설정, 알림 스킵")
+            return
+        msg = NotificationMessage(title=title, body=body, level=level)
+        asyncio.run(notifier.send_message(msg))
+    except Exception as e:
+        logger.warning(f"알림 발송 실패: {e}")
 
 
 def main():
@@ -50,6 +67,11 @@ def main():
         logger.info(f"총 {total}개 활성 심볼 감지")
     except Exception as e:
         logger.error(f"Universe 로드 실패: {e}")
+        _send_notification(
+            "주간 차트 생성 실패",
+            f"Universe 로드 실패: {e}",
+            NotificationLevel.ERROR,
+        )
         sys.exit(1)
 
     # 3. 배치 렌더링
@@ -65,6 +87,11 @@ def main():
     logger.info(f"배치 완료: 성공 {len(successes)} / 실패 {len(failures)}")
     if failures:
         logger.warning(f"실패 종목: {', '.join(failures)}")
+        _send_notification(
+            "주간 차트 생성 부분 실패",
+            f"성공 {len(successes)} / 실패 {len(failures)}\n실패 종목: {', '.join(failures)}",
+            NotificationLevel.WARNING,
+        )
     logger.info("=" * 40)
 
 

--- a/scripts/weekly_charts.sh
+++ b/scripts/weekly_charts.sh
@@ -4,9 +4,8 @@
 # 로컬 환경: 0 6 * * 6 /path/to/turtle_trading/scripts/weekly_charts.sh
 #
 # 기능:
-#   - fetch_universe_charts.py 실행
+#   - fetch_universe_charts.py 실행 (알림은 Python 스크립트가 직접 처리)
 #   - 로그 파일 저장 (logs/weekly_charts/)
-#   - 실패 시 notifier 알림 발송
 #   - 30일 이상 된 로그 자동 정리
 
 set -euo pipefail
@@ -30,34 +29,14 @@ if [ ! -f "$VENV_PATH" ]; then
     exit 1
 fi
 
-# 실패 시 알림 발송 함수
-send_failure_notification() {
-    local exit_code="$1"
-    local log_file="$2"
-    "$VENV_PATH" -c "
-import asyncio
-from src.notifier import NotificationManager, NotificationMessage, NotificationLevel
-async def notify():
-    mgr = NotificationManager()
-    msg = NotificationMessage(
-        title='주간 차트 생성 실패',
-        body='weekly_charts.sh 실행 실패 (exit code: $exit_code). 로그: $log_file',
-        level=NotificationLevel.ERROR,
-    )
-    await mgr.send_message(msg)
-asyncio.run(notify())
-" 2>/dev/null || echo "[$TIMESTAMP] WARNING: 알림 발송 실패 (notifier 설정 확인 필요)" >> "$log_file"
-}
-
 echo "[$TIMESTAMP] 주간 차트 생성 시작" | tee "$LOG_FILE"
 
-# 차트 생성 실행
+# 차트 생성 실행 (실패 알림은 fetch_universe_charts.py 내부에서 처리)
 if "$VENV_PATH" "$PROJECT_ROOT/scripts/fetch_universe_charts.py" >> "$LOG_FILE" 2>&1; then
     echo "[$(date +"%Y-%m-%d_%H%M%S")] 차트 생성 완료" | tee -a "$LOG_FILE"
 else
     EXIT_CODE=$?
     echo "[$(date +"%Y-%m-%d_%H%M%S")] ERROR: 차트 생성 실패 (exit code: $EXIT_CODE)" | tee -a "$LOG_FILE"
-    cd "$PROJECT_ROOT" && send_failure_notification "$EXIT_CODE" "$LOG_FILE"
     exit $EXIT_CODE
 fi
 

--- a/tests/test_weekly_charts.py
+++ b/tests/test_weekly_charts.py
@@ -45,12 +45,17 @@ class TestWeeklyChartsWrapper:
         content = WRAPPER_SCRIPT.read_text()
         assert "-mtime +30 -delete" in content
 
-    def test_wrapper_has_notification_on_failure(self):
-        """래퍼 스크립트가 실패 시 notifier를 호출한다"""
+    def test_wrapper_delegates_notification_to_python(self):
+        """래퍼 스크립트는 알림을 Python 스크립트에 위임한다 (직접 알림 코드 없음)"""
         content = WRAPPER_SCRIPT.read_text()
-        assert "send_failure_notification" in content
-        assert "NotificationManager" in content
-        assert "NotificationLevel.ERROR" in content
+        # 래퍼에는 알림 코드가 없어야 함 (Python 스크립트가 처리)
+        assert "NotificationManager" not in content
+        assert "NotificationLevel" not in content
+        # 대신 Python 스크립트에 알림 로직이 존재해야 함
+        chart_content = CHART_SCRIPT.read_text()
+        assert "load_config" in chart_content
+        assert "setup_notifier" in chart_content
+        assert "_send_notification" in chart_content
 
 
 class TestWrapperExecution:


### PR DESCRIPTION
## Summary
Fixes #170

PR #172 리뷰에서 지적된 두 가지 High 블로커 수정:

- **Docker crontab이 wrapper를 우회하여 알림 누락**: `fetch_universe_charts.py`에 `_send_notification()` 함수 추가. `load_config()` + `setup_notifier()`를 사용하여 Docker/로컬 양쪽 실행 경로에서 알림 동작
- **NotificationManager() no-op**: bare `NotificationManager()` 대신 `script_helpers`의 설정 로딩 헬퍼를 사용하여 실제 채널이 등록되도록 수정
- `weekly_charts.sh`에서 broken `send_failure_notification()` 제거 (Python에 위임)
- 테스트 업데이트: 알림 위임 구조 검증 (`test_wrapper_delegates_notification_to_python`)

## Test plan
- [x] 12/12 weekly charts tests pass
- [x] ruff lint clean
- [ ] CI (lint + test) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)