### PR TITLE
chore: 테스트 견고성 개선 — behavior test + MPLBACKEND 고정

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 Turtle Trading 테스트 공통 Fixtures
 """
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -9,6 +10,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+
+# macOS 기본 Matplotlib 백엔드(macosx)는 headless 환경에서 abort 가능.
+# 테스트 안정성을 위해 Agg 백엔드 고정.
+os.environ.setdefault("MPLBACKEND", "Agg")
 
 
 @pytest.fixture

--- a/tests/test_run_backtest.py
+++ b/tests/test_run_backtest.py
@@ -388,17 +388,49 @@ class TestCLIRiskWiring:
 class TestPathResolution:
     """경로 해석 회귀 테스트"""
 
-    def test_universe_yaml_path_is_absolute(self):
-        """run_backtest.py가 Path(__file__) 기반 절대경로로 universe.yaml을 참조하는지 검증"""
-        import inspect
+    @patch("scripts.run_backtest.TurtleBacktester")
+    def test_universe_yaml_resolves_from_any_cwd(self, mock_bt_cls, tmp_path):
+        """CWD가 프로젝트 루트가 아니어도 config/universe.yaml이 올바르게 로드되는지 검증"""
+        import os
 
-        from scripts import run_backtest as rb
+        mock_bt = MagicMock()
+        mock_bt.run.return_value = BacktestResult(config=BacktestConfig())
+        mock_bt_cls.return_value = mock_bt
 
-        source = inspect.getsource(rb.run_backtest)
-        # 상대경로 "config/universe.yaml" 리터럴이 없어야 함
-        assert 'yaml_path="config/universe.yaml"' not in source
-        # Path(__file__) 기반 패턴이 존재해야 함
-        assert "Path(__file__)" in source
+        mock_data = {
+            "SPY": pd.DataFrame(
+                {
+                    "date": pd.date_range("2024-01-01", periods=10, freq="B"),
+                    "open": [100.0] * 10,
+                    "high": [105.0] * 10,
+                    "low": [95.0] * 10,
+                    "close": [102.0] * 10,
+                    "volume": [1000000] * 10,
+                }
+            )
+        }
+
+        args = MagicMock()
+        args.capital = 100000.0
+        args.risk = 0.01
+        args.system = 1
+        args.no_filter = False
+        args.commission = 0.001
+        args.no_risk_limits = False
+
+        # CWD를 임시 디렉터리로 변경하여 상대경로가 깨지는 상황 재현
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            # 상대경로였다면 여기서 FileNotFoundError 또는 기본 8종목 fallback 발생
+            run_backtest(mock_data, args)
+        finally:
+            os.chdir(original_cwd)
+
+        # UniverseManager가 호출되었고 TurtleBacktester에 symbol_groups가 전달됨
+        _, kwargs = mock_bt_cls.call_args
+        # symbol_groups가 None이 아니면 universe.yaml이 정상 로드된 것
+        assert kwargs["symbol_groups"] is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 경로 회귀 테스트를 소스 문자열 검사에서 **임시 디렉터리 behavior test**로 교체 — CWD를 tmp_path로 변경 후 `run_backtest()`가 정상 동작하는지 직접 검증
- `conftest.py`에 `MPLBACKEND=Agg` 기본값 설정 — macOS 기본 백엔드(macosx)의 headless abort 방지

## Test plan
- [x] `TestPathResolution::test_universe_yaml_resolves_from_any_cwd` 통과
- [x] 전체 `test_run_backtest.py` 17/17 통과
- [x] ruff 린트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)