### PR TITLE
[#187] feat: 거래 분석 리포트 — 진입/청산 사유 + 차트 마커

### DIFF
--- a/src/analytics.py
+++ b/src/analytics.py
@@ -462,6 +462,65 @@ class TradeAnalytics:
             "total_pnl": round(total_pnl, 2),
         }
 
+    def generate_trade_detail_report(self, trade: dict) -> str:
+        """
+        개별 거래의 상세 리포트를 마크다운 문자열로 반환한다.
+
+        Args:
+            trade: 거래 딕셔너리 (symbol, entry_date, exit_date, entry_price,
+                   exit_price, pnl, r_multiple, entry_reason, exit_reason 등 포함)
+
+        Returns:
+            마크다운 형식의 거래 상세 리포트 문자열
+        """
+        symbol = trade.get("symbol", "N/A")
+        entry_date = trade.get("entry_date", "N/A")
+        exit_date = trade.get("exit_date", "N/A")
+        entry_price = trade.get("entry_price", 0.0) or 0.0
+        exit_price = trade.get("exit_price", 0.0) or 0.0
+        pnl = trade.get("pnl", 0.0) or 0.0
+        r_multiple = trade.get("r_multiple", None)
+        entry_reason = trade.get("entry_reason", "") or ""
+        exit_reason = trade.get("exit_reason", "") or ""
+        direction = trade.get("direction", "N/A")
+        total_shares = trade.get("total_shares", 0) or 0
+
+        # 보유 기간 계산
+        holding_days = "N/A"
+        try:
+            from datetime import datetime
+
+            fmt = "%Y-%m-%d"
+            entry_dt = datetime.strptime(str(entry_date)[:10], fmt)
+            exit_dt = datetime.strptime(str(exit_date)[:10], fmt)
+            holding_days = str((exit_dt - entry_dt).days) + "일"
+        except Exception:
+            pass
+
+        pnl_sign = "+" if pnl >= 0 else ""
+        r_str = f"{r_multiple:.2f}R" if r_multiple is not None else "N/A"
+
+        lines = [
+            f"## 거래 상세 리포트: {symbol}",
+            "",
+            "| 항목 | 내용 |",
+            "|------|------|",
+            f"| 종목 | {symbol} |",
+            f"| 방향 | {direction} |",
+            f"| 수량 | {total_shares:,}주 |",
+            f"| 진입일 | {entry_date} |",
+            f"| 청산일 | {exit_date} |",
+            f"| 보유 기간 | {holding_days} |",
+            f"| 진입가 | ${entry_price:,.2f} |",
+            f"| 청산가 | ${exit_price:,.2f} |",
+            f"| 손익 | {pnl_sign}${pnl:,.2f} |",
+            f"| R-배수 | {r_str} |",
+            f"| 진입 사유 | {entry_reason if entry_reason else '—'} |",
+            f"| 청산 사유 | {exit_reason if exit_reason else '—'} |",
+        ]
+
+        return "\n".join(lines)
+
 
 # ── 독립 함수 ──────────────────────────────────────────────────────────────
 

--- a/src/local_chart_renderer.py
+++ b/src/local_chart_renderer.py
@@ -124,6 +124,139 @@ def render_chart(
         return False
 
 
+def render_trade_chart(
+    symbol: str,
+    df: pd.DataFrame,
+    entry_date: str,
+    entry_price: float,
+    exit_date: str,
+    exit_price: float,
+    entry_reason: str = "",
+    exit_reason: str = "",
+    stop_loss: Optional[float] = None,
+    output_dir: Optional[Path] = None,
+) -> Optional[Path]:
+    """진입/청산 마커가 포함된 거래 차트를 PNG로 렌더링한다.
+
+    Args:
+        symbol: 종목 코드
+        df: OHLCV DataFrame (DatetimeIndex)
+        entry_date: 진입일 (YYYY-MM-DD)
+        entry_price: 진입가
+        exit_date: 청산일 (YYYY-MM-DD)
+        exit_price: 청산가
+        entry_reason: 진입 사유 (레이블용)
+        exit_reason: 청산 사유 (레이블용)
+        stop_loss: 손절가 (있을 경우 수평선 표시)
+        output_dir: 출력 디렉토리 (None이면 현재 디렉토리)
+
+    Returns:
+        저장된 파일 경로, 실패 시 None
+    """
+    if df.empty or len(df) < 5:
+        logger.warning(f"[{symbol}] 데이터 부족, 거래 차트 생성 스킵")
+        return None
+
+    try:
+        out_dir = Path(output_dir) if output_dir is not None else Path(".")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        output_path = out_dir / f"{symbol}_trade.png"
+
+        # 진입/청산 마커 시리즈 구성
+        entry_markers = pd.Series(float("nan"), index=df.index)
+        exit_markers = pd.Series(float("nan"), index=df.index)
+
+        entry_dt = pd.Timestamp(entry_date)
+        exit_dt = pd.Timestamp(exit_date)
+
+        # 가장 가까운 인덱스 날짜를 찾아 마커 위치 설정
+        if entry_dt in df.index:
+            entry_markers[entry_dt] = entry_price
+        else:
+            nearest = df.index[df.index.get_indexer([entry_dt], method="nearest")[0]]
+            entry_markers[nearest] = entry_price
+
+        if exit_dt in df.index:
+            exit_markers[exit_dt] = exit_price
+        else:
+            nearest = df.index[df.index.get_indexer([exit_dt], method="nearest")[0]]
+            exit_markers[nearest] = exit_price
+
+        addplots = []
+        entry_label = f"진입 {entry_reason}".strip() if entry_reason else "진입"
+        exit_label = f"청산 {exit_reason}".strip() if exit_reason else "청산"
+
+        addplots.append(
+            mpf.make_addplot(
+                entry_markers,
+                type="scatter",
+                marker="^",
+                markersize=120,
+                color="green",
+                label=entry_label,
+            )
+        )
+        addplots.append(
+            mpf.make_addplot(
+                exit_markers,
+                type="scatter",
+                marker="v",
+                markersize=120,
+                color="red",
+                label=exit_label,
+            )
+        )
+
+        # 손절 수평선
+        if stop_loss is not None:
+            stop_series = pd.Series(stop_loss, index=df.index)
+            addplots.append(
+                mpf.make_addplot(
+                    stop_series,
+                    color="red",
+                    linestyle="--",
+                    width=0.8,
+                    label="손절",
+                )
+            )
+
+        mc = mpf.make_marketcolors(
+            up="#ef5350",
+            down="#2196f3",
+            edge="inherit",
+            wick="inherit",
+            volume="in",
+        )
+        style = mpf.make_mpf_style(
+            marketcolors=mc,
+            gridstyle="-",
+            gridcolor="#e0e0e0",
+            facecolor="white",
+        )
+
+        title = f"{symbol} 거래 차트"
+        mpf.plot(
+            df,
+            type="candle",
+            style=style,
+            addplot=addplots,
+            volume=True,
+            volume_panel=1,
+            panel_ratios=(6, 2),
+            figsize=(14, 7),
+            tight_layout=True,
+            title=title,
+            savefig=dict(fname=str(output_path), dpi=100, bbox_inches="tight"),
+        )
+
+        logger.info(f"[{symbol}] 거래 차트 저장: {output_path}")
+        return output_path
+
+    except Exception as e:
+        logger.error(f"[{symbol}] 거래 차트 렌더링 실패: {e}")
+        return None
+
+
 class BatchChartRenderer:
     """유니버스 전체 차트를 배치로 렌더링한다."""
 

--- a/src/position_tracker.py
+++ b/src/position_tracker.py
@@ -65,6 +65,7 @@ class Position:
     exit_date: Optional[str] = None
     exit_price: Optional[float] = None
     exit_reason: Optional[str] = None
+    entry_reason: Optional[str] = None
     pnl: Optional[float] = None
     pnl_pct: Optional[float] = None
     r_multiple: Optional[float] = None  # N의 배수로 수익 표현
@@ -76,7 +77,11 @@ class Position:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Position":
-        return cls(**dict(data))
+        from dataclasses import fields
+
+        known_keys = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in known_keys}
+        return cls(**filtered)
 
     def calculate_pnl(self, exit_price: float) -> float:
         """손익 계산"""

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -781,3 +781,51 @@ class TestDetectAnomalies:
         """계좌 자산 0일 때 빈 리스트"""
         trade = self._make_trade(pnl=-100.0)
         assert detect_anomalies([trade], account_equity=0) == []
+
+
+class TestGenerateTradeDetailReport:
+    """generate_trade_detail_report 테스트"""
+
+    TRADE = {
+        "symbol": "SPY",
+        "system": 1,
+        "direction": "LONG",
+        "entry_date": "2025-01-15",
+        "exit_date": "2025-02-10",
+        "entry_price": 450.0,
+        "exit_price": 470.0,
+        "stop_loss": 440.0,
+        "total_shares": 100,
+        "pnl": 2000.0,
+        "r_multiple": 2.0,
+        "entry_reason": "S1_20D_BREAKOUT",
+        "exit_reason": "10D_LOW_EXIT",
+    }
+
+    def test_generate_trade_detail_report(self):
+        """마크다운 출력에 핵심 필드가 포함된다"""
+        analytics = TradeAnalytics([self.TRADE])
+        report = analytics.generate_trade_detail_report(self.TRADE)
+
+        assert isinstance(report, str)
+        assert "SPY" in report
+        assert "S1_20D_BREAKOUT" in report
+        assert "10D_LOW_EXIT" in report
+        assert "2025-01-15" in report
+        assert "2025-02-10" in report
+        assert "2.00R" in report
+        assert "LONG" in report
+
+    def test_report_without_reasons(self):
+        """진입/청산 사유 없는 거래도 오류 없이 처리된다"""
+        trade = {**self.TRADE, "entry_reason": None, "exit_reason": ""}
+        analytics = TradeAnalytics([trade])
+        report = analytics.generate_trade_detail_report(trade)
+        assert isinstance(report, str)
+        assert "SPY" in report
+
+    def test_report_holding_period(self):
+        """보유 기간이 일(日) 단위로 계산된다"""
+        analytics = TradeAnalytics([self.TRADE])
+        report = analytics.generate_trade_detail_report(self.TRADE)
+        assert "26일" in report  # 2025-01-15 to 2025-02-10 = 26일

--- a/tests/test_local_chart_renderer.py
+++ b/tests/test_local_chart_renderer.py
@@ -267,3 +267,52 @@ class TestRenderChartBoundary:
         output = str(tmp_path / "five.png")
         assert render_chart(df, "FIVE", "Five Rows", output) is True
         assert os.path.exists(output)
+
+
+class TestRenderTradeChart:
+    """render_trade_chart 테스트"""
+
+    def test_render_trade_chart_creates_png(self, sample_ohlcv, tmp_path):
+        """render_trade_chart가 PNG 파일을 생성한다"""
+        from src.local_chart_renderer import render_trade_chart
+
+        entry_date = str(sample_ohlcv.index[10].date())
+        exit_date = str(sample_ohlcv.index[40].date())
+
+        result = render_trade_chart(
+            symbol="SPY",
+            df=sample_ohlcv,
+            entry_date=entry_date,
+            entry_price=float(sample_ohlcv["Close"].iloc[10]),
+            exit_date=exit_date,
+            exit_price=float(sample_ohlcv["Close"].iloc[40]),
+            output_dir=tmp_path,
+        )
+
+        assert result is not None
+        assert result.exists()
+        assert result.name == "SPY_trade.png"
+        assert result.stat().st_size > 1000
+
+    def test_render_trade_chart_with_markers(self, sample_ohlcv, tmp_path):
+        """진입/청산 사유 마커 포함 시 정상 실행된다"""
+        from src.local_chart_renderer import render_trade_chart
+
+        entry_date = str(sample_ohlcv.index[5].date())
+        exit_date = str(sample_ohlcv.index[50].date())
+
+        result = render_trade_chart(
+            symbol="QQQ",
+            df=sample_ohlcv,
+            entry_date=entry_date,
+            entry_price=float(sample_ohlcv["Close"].iloc[5]),
+            exit_date=exit_date,
+            exit_price=float(sample_ohlcv["Close"].iloc[50]),
+            entry_reason="S1_20D_BREAKOUT",
+            exit_reason="10D_LOW_EXIT",
+            stop_loss=float(sample_ohlcv["Close"].iloc[5]) * 0.95,
+            output_dir=tmp_path,
+        )
+
+        assert result is not None
+        assert result.exists()

--- a/tests/test_position_tracker.py
+++ b/tests/test_position_tracker.py
@@ -318,3 +318,70 @@ class TestPersistence:
         assert summary["total_positions"] == 2
         assert summary["open_positions"] == 1
         assert summary["closed_positions"] == 1
+
+
+class TestEntryReason:
+    def test_entry_reason_serialization(self, tracker):
+        """entry_reason 필드가 직렬화/역직렬화된다"""
+        from src.position_tracker import Position
+
+        pos = tracker.open_position("SPY", 1, "LONG", 100.0, 2.5, 40)
+        pos.entry_reason = "S1_20D_BREAKOUT"
+        d = pos.to_dict()
+        restored = Position.from_dict(d)
+        assert restored.entry_reason == "S1_20D_BREAKOUT"
+
+    def test_from_dict_unknown_key_resilience(self):
+        """from_dict은 알 수 없는 키를 무시한다"""
+        from src.position_tracker import Position
+        from src.types import Direction
+
+        data = {
+            "position_id": "pos-001",
+            "symbol": "SPY",
+            "system": 1,
+            "direction": Direction.LONG,
+            "entry_date": "2025-01-01",
+            "entry_price": 100.0,
+            "entry_n": 2.5,
+            "stop_loss": 95.0,
+            "total_shares": 40,
+            "units": 1,
+            "max_units": 4,
+            "shares_per_unit": 40,
+            "pyramid_level": 0,
+            "exit_period": 10,
+            "status": "open",
+            "last_update": "2025-01-01",
+            "unknown_future_field": "some_value",  # 알 수 없는 키
+        }
+        pos = Position.from_dict(data)
+        assert pos.symbol == "SPY"
+        assert pos.entry_price == 100.0
+
+    def test_from_dict_missing_optional_key(self):
+        """from_dict은 entry_reason 없이도 동작한다 (하위 호환)"""
+        from src.position_tracker import Position
+        from src.types import Direction
+
+        data = {
+            "position_id": "pos-002",
+            "symbol": "QQQ",
+            "system": 2,
+            "direction": Direction.LONG,
+            "entry_date": "2025-02-01",
+            "entry_price": 200.0,
+            "entry_n": 3.0,
+            "stop_loss": 194.0,
+            "total_shares": 30,
+            "units": 1,
+            "max_units": 4,
+            "shares_per_unit": 30,
+            "pyramid_level": 0,
+            "exit_period": 20,
+            "status": "open",
+            "last_update": "2025-02-01",
+            # entry_reason 없음
+        }
+        pos = Position.from_dict(data)
+        assert pos.entry_reason is None


### PR DESCRIPTION
## Summary
- Position에 `entry_reason` 필드 추가 + `from_dict()` unknown-key 필터링 (하위호환)
- `render_trade_chart()`: 진입/청산 마커 + 손절선 포함 거래 차트 렌더링
- `generate_trade_detail_report()`: 개별 거래 마크다운 상세 리포트

## Test plan
- [x] `test_entry_reason_serialization` — 직렬화/역직렬화
- [x] `test_from_dict_unknown_key_resilience` — 미래 필드 무시
- [x] `test_from_dict_missing_optional_key` — 하위호환
- [x] `test_render_trade_chart_creates_png` — PNG 생성
- [x] `test_render_trade_chart_with_markers` — 마커+손절선 포함
- [x] `test_generate_trade_detail_report` — 핵심 필드 포함
- [x] `test_report_without_reasons` — 사유 없는 거래
- [x] `test_report_holding_period` — 보유기간 계산

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)