### PR TITLE
[#189] feat: 알림 고도화 — 일일 PnL 요약, 주간 성과, 이상 거래 감지

### DIFF
--- a/scripts/check_positions.py
+++ b/scripts/check_positions.py
@@ -578,7 +578,37 @@ async def _run_checks():
             reason=budget_reason,
         )
 
-    # 5. 요약 리포트
+    # 5. 이상 거래 감지
+    try:
+        from src.analytics import detect_anomalies
+
+        closed_positions = [p for p in tracker.get_all_positions() if p.status == "closed"]
+        recent_trade_dicts = []
+        for p in closed_positions:
+            recent_trade_dicts.append(
+                {
+                    "symbol": p.symbol,
+                    "system": p.system,
+                    "direction": p.direction.value if hasattr(p.direction, "value") else p.direction,
+                    "entry_price": p.entry_price,
+                    "exit_price": p.exit_price,
+                    "stop_loss": p.stop_loss,
+                    "total_shares": p.total_shares,
+                    "pnl": p.pnl,
+                    "exit_date": p.exit_date,
+                }
+            )
+        account_equity = config.get("initial_capital", 100000.0)
+        anomalies = detect_anomalies(recent_trade_dicts, account_equity)
+        if anomalies:
+            logger.warning(f"이상 거래 감지: {len(anomalies)}건")
+            await notifier.send_anomaly_alert(anomalies)
+        else:
+            logger.info("이상 거래 없음")
+    except Exception as e:
+        logger.error(f"이상 거래 감지 오류: {e}")
+
+    # 6. 요약 리포트
     summary = tracker.get_summary()
     logger.info(f"포지션 요약: {summary}")
 

--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -14,6 +14,7 @@ from src.market_calendar import get_market_status
 from src.position_tracker import PositionTracker
 from src.risk_manager import PortfolioRiskManager
 from src.script_helpers import load_config, setup_notifier
+from src.spot_price import SpotPriceFetcher
 from src.universe_manager import UniverseManager
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -41,6 +42,59 @@ def generate_cost_summary(today: str) -> dict:
     except Exception as e:
         logger.warning(f"비용 요약 조회 실패: {e}")
         return {}
+
+
+def generate_pnl_summary(
+    today: str,
+    trades,
+    tracker: PositionTracker | None = None,
+    data_store: ParquetDataStore | None = None,
+) -> dict:
+    """오늘의 PnL 요약: 실현 PnL + 미실현 PnL.
+
+    spot_price API 실패 시 미실현 PnL은 'N/A'로 표시하고 실현 PnL만 반환.
+    """
+    # 실현 PnL: 오늘 청산된 거래의 PnL 합산
+    realized_pnl = 0.0
+    if not trades.empty:
+        today_trades = trades[trades.get("exit_date", trades.index).astype(str).str.startswith(today)]
+        if not today_trades.empty:
+            realized_pnl = today_trades["pnl"].sum()
+
+    # 미실현 PnL: 오픈 포지션의 현재가 기준 평가 손익
+    unrealized_pnl: float | str = "N/A"
+    if tracker is not None:
+        open_positions = tracker.get_open_positions()
+        if open_positions:
+            try:
+                spot_fetcher = SpotPriceFetcher()
+                total_unrealized = 0.0
+                has_price = False
+
+                for pos in open_positions:
+                    try:
+                        spot = asyncio.get_event_loop().run_until_complete(spot_fetcher.fetch_spot_price(pos.symbol))
+                        if spot is not None:
+                            current_price = spot["price"]
+                            if pos.direction.value == "LONG":
+                                pos_pnl = (current_price - pos.entry_price) * pos.total_shares
+                            else:
+                                pos_pnl = (pos.entry_price - current_price) * pos.total_shares
+                            total_unrealized += pos_pnl
+                            has_price = True
+                    except Exception as e:
+                        logger.warning(f"미실현 PnL 조회 실패: {pos.symbol} - {e}")
+                        continue
+
+                if has_price:
+                    unrealized_pnl = total_unrealized
+            except Exception as e:
+                logger.warning(f"spot_price API 실패, 미실현 PnL은 N/A: {e}")
+
+    return {
+        "realized_pnl": realized_pnl,
+        "unrealized_pnl": unrealized_pnl,
+    }
 
 
 def generate_report(
@@ -125,6 +179,9 @@ def generate_report(
         except Exception as e:
             logger.warning(f"R-배수 분석 실패: {e}")
 
+    # PnL 요약 (오늘 기준)
+    pnl_summary = generate_pnl_summary(today, trades, tracker, data_store)
+
     # 비용 요약 (오늘 기준)
     cost_summary = generate_cost_summary(today)
 
@@ -143,6 +200,7 @@ def generate_report(
         "캐시 파일": cache_stats["cache_files"],
         "데이터 크기": f"{cache_stats['total_size_mb']:.1f}MB",
         "비용 요약": cost_summary,
+        "pnl_summary": pnl_summary,
     }
 
 
@@ -172,6 +230,10 @@ async def main():
 
     # 알림 전송
     await notifier.send_daily_report(report_data)
+
+    # PnL 요약 알림
+    if "pnl_summary" in report_data:
+        await notifier.send_pnl_summary(report_data["pnl_summary"])
 
     # 오래된 캐시 정리
     data_store.cleanup_old_cache(max_age_days=7)

--- a/scripts/weekly_report.py
+++ b/scripts/weekly_report.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List
 
+from src.analytics import TradeAnalytics
 from src.data_store import ParquetDataStore
 from src.notifier import NotificationLevel, NotificationMessage
 from src.position_tracker import PositionStatus, PositionTracker
@@ -169,6 +170,58 @@ def format_risk_summary(risk_manager: PortfolioRiskManager, positions: List) -> 
     return "\n".join(lines)
 
 
+def get_weekly_performance_stats(closed_trades: List) -> Dict:
+    """주간 성과 통계 계산 (TradeAnalytics 활용)"""
+    if not closed_trades:
+        return {
+            "win_rate": 0.0,
+            "avg_r": 0.0,
+            "total_pnl": 0.0,
+            "profit_factor": 0.0,
+        }
+
+    trade_dicts = []
+    for pos in closed_trades:
+        trade_dicts.append(
+            {
+                "symbol": pos.symbol,
+                "system": pos.system,
+                "direction": pos.direction.value if hasattr(pos.direction, "value") else pos.direction,
+                "entry_price": pos.entry_price,
+                "exit_price": pos.exit_price,
+                "stop_loss": pos.stop_loss,
+                "total_shares": pos.total_shares,
+                "pnl": pos.pnl or 0,
+                "exit_date": pos.exit_date,
+            }
+        )
+
+    analytics = TradeAnalytics(trade_dicts)
+    stats = analytics.get_win_loss_stats()
+    r_dist = analytics.get_r_distribution()
+
+    return {
+        "win_rate": stats["win_rate"],
+        "avg_r": r_dist["mean_r"],
+        "total_pnl": sum(t.get("pnl", 0) for t in trade_dicts),
+        "profit_factor": stats["profit_factor"],
+    }
+
+
+def format_performance_stats(stats: Dict) -> str:
+    """주간 성과 통계 포맷팅"""
+    if stats["win_rate"] == 0 and stats["total_pnl"] == 0:
+        return "  이번 주 청산 거래 없음"
+
+    lines = [
+        f"  승률: {stats['win_rate']:.1%}",
+        f"  평균 R: {stats['avg_r']:.2f}",
+        f"  총 PnL: ${stats['total_pnl']:+,.0f}",
+        f"  Profit Factor: {stats['profit_factor']:.2f}",
+    ]
+    return "\n".join(lines)
+
+
 async def main(args):
     """메인 함수"""
     logger.info("=== 주간 리포트 생성 ===")
@@ -201,6 +254,9 @@ async def main(args):
         logger.error(f"데이터 수집 오류: {e}")
         return
 
+    # 주간 성과 통계
+    perf_stats = get_weekly_performance_stats(closed_trades)
+
     # 주간 리포트 본문 구성
     week_start = get_week_start()
     _week_end = week_start + timedelta(days=7)
@@ -215,6 +271,9 @@ async def main(args):
 
 💰 **CLOSED TRADES**
 {format_closed_trades_summary(closed_trades, universe.get_display_name)}
+
+📊 **PERFORMANCE STATS**
+{format_performance_stats(perf_stats)}
 
 📈 **OPEN POSITIONS**
 {format_open_positions_summary(open_positions, universe.get_display_name)}
@@ -236,6 +295,9 @@ async def main(args):
         await notifier.send_message(
             NotificationMessage(title="Weekly Trading Report", body=report_body, level=NotificationLevel.INFO)
         )
+        # 성과 통계 알림
+        if perf_stats["total_pnl"] != 0 or perf_stats["win_rate"] != 0:
+            await notifier.send_performance_alert(perf_stats)
         logger.info("주간 리포트 전송 완료")
     else:
         logger.info("--send 플래그가 없어서 알림 전송을 건너뜁니다")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -296,3 +296,69 @@ class NotificationManager:
             title="일일 리포트", body="오늘의 포트폴리오 현황입니다.", level=NotificationLevel.INFO, data=report_data
         )
         return await self.send_all(message)
+
+    async def send_pnl_summary(self, pnl_data: Dict):
+        """일일 PnL 요약 알림"""
+        realized = pnl_data.get("realized_pnl", 0)
+        unrealized = pnl_data.get("unrealized_pnl", "N/A")
+
+        if isinstance(unrealized, (int, float)):
+            total = realized + unrealized
+            body = f"일일 PnL: ${total:+,.0f} (실현 ${realized:+,.0f} / 미실현 ${unrealized:+,.0f})"
+        else:
+            body = f"일일 PnL: 실현 ${realized:+,.0f} / 미실현 {unrealized}"
+
+        message = NotificationMessage(
+            title="일일 PnL 요약",
+            body=body,
+            level=NotificationLevel.INFO,
+            data=pnl_data,
+        )
+        return await self.send_all(message)
+
+    async def send_performance_alert(self, stats: Dict):
+        """주간 성과 알림"""
+        win_rate = stats.get("win_rate", 0)
+        avg_r = stats.get("avg_r", 0)
+        total_pnl = stats.get("total_pnl", 0)
+        profit_factor = stats.get("profit_factor", 0)
+
+        body = (
+            f"주간 성과 요약\n"
+            f"승률: {win_rate:.1%}\n"
+            f"평균 R: {avg_r:.2f}\n"
+            f"총 PnL: ${total_pnl:+,.0f}\n"
+            f"Profit Factor: {profit_factor:.2f}"
+        )
+
+        message = NotificationMessage(
+            title="주간 성과 알림",
+            body=body,
+            level=NotificationLevel.INFO,
+            data=stats,
+        )
+        return await self.send_all(message)
+
+    async def send_anomaly_alert(self, anomalies: List[Dict]):
+        """이상 거래 감지 알림"""
+        if not anomalies:
+            return {}
+
+        lines = []
+        max_severity = NotificationLevel.WARNING
+        for anomaly in anomalies:
+            severity = anomaly.get("severity", "WARNING")
+            anomaly_type = anomaly.get("type", "UNKNOWN")
+            description = anomaly.get("description", "")
+            lines.append(f"[{severity}] {anomaly_type}: {description}")
+            if severity == "ERROR":
+                max_severity = NotificationLevel.ERROR
+
+        body = f"이상 거래 {len(anomalies)}건 감지\n\n" + "\n".join(lines)
+
+        message = NotificationMessage(
+            title="이상 거래 감지",
+            body=body,
+            level=max_severity,
+        )
+        return await self.send_all(message)

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -1,0 +1,68 @@
+"""scripts/daily_report.py 단위 테스트"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from scripts.daily_report import generate_pnl_summary, generate_report
+
+
+class TestGenerateReport:
+    def test_daily_report_includes_pnl_summary(self):
+        """generate_report 결과에 pnl_summary 섹션이 포함된다"""
+        mock_data_store = MagicMock()
+        mock_data_store.load_signals.return_value = pd.DataFrame()
+        mock_data_store.load_trades.return_value = pd.DataFrame()
+        mock_data_store.get_cache_stats.return_value = {"cache_files": 0, "total_size_mb": 0.0}
+
+        pnl_mock = {"realized_pnl": 0, "unrealized_pnl": "N/A"}
+        with patch("scripts.daily_report.get_market_status", return_value="closed"):
+            with patch("scripts.daily_report.generate_cost_summary", return_value={}):
+                with patch("scripts.daily_report.generate_pnl_summary", return_value=pnl_mock):
+                    report = generate_report(mock_data_store)
+
+        assert "pnl_summary" in report
+        assert "realized_pnl" in report["pnl_summary"]
+
+
+class TestGeneratePnlSummary:
+    def test_pnl_summary_no_trades(self):
+        """거래가 없으면 realized_pnl=0, unrealized_pnl=N/A"""
+        result = generate_pnl_summary("2026-03-10", pd.DataFrame(), None, None)
+        assert result["realized_pnl"] == 0.0
+        assert result["unrealized_pnl"] == "N/A"
+
+    def test_pnl_summary_with_realized(self):
+        """오늘 청산된 거래의 실현 PnL이 합산된다"""
+        trades = pd.DataFrame(
+            {
+                "exit_date": ["2026-03-10", "2026-03-10", "2026-03-09"],
+                "pnl": [100.0, 200.0, 500.0],
+            }
+        )
+        result = generate_pnl_summary("2026-03-10", trades, None, None)
+        assert result["realized_pnl"] == 300.0
+
+    def test_daily_report_spot_price_failure_graceful(self):
+        """spot_price API 실패 시 미실현 PnL은 N/A로 표시"""
+        mock_tracker = MagicMock()
+        mock_pos = MagicMock()
+        mock_pos.symbol = "SPY"
+        mock_pos.direction.value = "LONG"
+        mock_pos.entry_price = 500.0
+        mock_pos.total_shares = 10
+        mock_tracker.get_open_positions.return_value = [mock_pos]
+
+        with patch("scripts.daily_report.SpotPriceFetcher") as mock_fetcher_cls:
+            mock_fetcher = MagicMock()
+            mock_fetcher_cls.return_value = mock_fetcher
+
+            async def _raise(*a, **kw):
+                raise ConnectionError("API down")
+
+            mock_fetcher.fetch_spot_price = _raise
+
+            result = generate_pnl_summary("2026-03-10", pd.DataFrame(), mock_tracker, None)
+
+        assert result["unrealized_pnl"] == "N/A"
+        assert result["realized_pnl"] == 0.0

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -493,3 +493,129 @@ class TestSecurityFixes:
         """올바르지 않은 경로는 ValueError를 발생시킨다."""
         with pytest.raises(ValueError, match="webhook path"):
             DiscordChannel(webhook_url="https://discord.com/other/path")
+
+
+class TestPnlSummary:
+    @pytest.mark.asyncio
+    async def test_send_pnl_summary(self):
+        """PnL 요약 메시지 포맷 검증"""
+        manager = NotificationManager()
+        mock_ch = AsyncMock()
+        mock_ch.__class__.__name__ = "TestCh"
+        mock_ch.send = AsyncMock(return_value=True)
+        manager.add_channel(mock_ch)
+        manager._health["TestCh"] = {"success": 0, "failure": 0}
+
+        pnl_data = {"realized_pnl": 500.0, "unrealized_pnl": 734.0}
+        results = await manager.send_pnl_summary(pnl_data)
+        assert "TestCh" in results
+
+        # 전송된 메시지 검증
+        sent_msg = mock_ch.send.call_args[0][0]
+        assert "일일 PnL 요약" in sent_msg.title
+        assert "실현" in sent_msg.body
+        assert "미실현" in sent_msg.body
+        assert sent_msg.level == NotificationLevel.INFO
+
+    @pytest.mark.asyncio
+    async def test_send_pnl_summary_unrealized_na(self):
+        """미실현 PnL이 N/A인 경우 포맷 검증"""
+        manager = NotificationManager()
+        mock_ch = AsyncMock()
+        mock_ch.__class__.__name__ = "TestCh"
+        mock_ch.send = AsyncMock(return_value=True)
+        manager.add_channel(mock_ch)
+        manager._health["TestCh"] = {"success": 0, "failure": 0}
+
+        pnl_data = {"realized_pnl": 500.0, "unrealized_pnl": "N/A"}
+        await manager.send_pnl_summary(pnl_data)
+
+        sent_msg = mock_ch.send.call_args[0][0]
+        assert "N/A" in sent_msg.body
+
+
+class TestPerformanceAlert:
+    @pytest.mark.asyncio
+    async def test_send_performance_alert(self):
+        """주간 성과 알림 메시지 포맷 검증"""
+        manager = NotificationManager()
+        mock_ch = AsyncMock()
+        mock_ch.__class__.__name__ = "TestCh"
+        mock_ch.send = AsyncMock(return_value=True)
+        manager.add_channel(mock_ch)
+        manager._health["TestCh"] = {"success": 0, "failure": 0}
+
+        stats = {
+            "win_rate": 0.65,
+            "avg_r": 1.5,
+            "total_pnl": 2500.0,
+            "profit_factor": 2.1,
+        }
+        results = await manager.send_performance_alert(stats)
+        assert "TestCh" in results
+
+        sent_msg = mock_ch.send.call_args[0][0]
+        assert "주간 성과 알림" in sent_msg.title
+        assert "65.0%" in sent_msg.body
+        assert "1.50" in sent_msg.body
+        assert "2.10" in sent_msg.body
+        assert sent_msg.level == NotificationLevel.INFO
+
+
+class TestAnomalyAlert:
+    @pytest.mark.asyncio
+    async def test_send_anomaly_alert(self):
+        """이상 거래 감지 알림 포맷 검증"""
+        manager = NotificationManager()
+        mock_ch = AsyncMock()
+        mock_ch.__class__.__name__ = "TestCh"
+        mock_ch.send = AsyncMock(return_value=True)
+        manager.add_channel(mock_ch)
+        manager._health["TestCh"] = {"success": 0, "failure": 0}
+
+        anomalies = [
+            {"type": "OVERSIZED_LOSS", "severity": "ERROR", "description": "R-배수 -4.2: SPY"},
+            {"type": "CONSECUTIVE_LOSSES", "severity": "WARNING", "description": "연속 5건 손실"},
+        ]
+        results = await manager.send_anomaly_alert(anomalies)
+        assert "TestCh" in results
+
+        sent_msg = mock_ch.send.call_args[0][0]
+        assert "이상 거래 감지" in sent_msg.title
+        assert "2건" in sent_msg.body
+        assert "OVERSIZED_LOSS" in sent_msg.body
+        assert "CONSECUTIVE_LOSSES" in sent_msg.body
+        # ERROR severity가 있으면 ERROR 레벨
+        assert sent_msg.level == NotificationLevel.ERROR
+
+    @pytest.mark.asyncio
+    async def test_send_anomaly_alert_empty(self):
+        """빈 anomaly 리스트 전송 시 아무 것도 보내지 않는다"""
+        manager = NotificationManager()
+        mock_ch = AsyncMock()
+        mock_ch.__class__.__name__ = "TestCh"
+        mock_ch.send = AsyncMock(return_value=True)
+        manager.add_channel(mock_ch)
+        manager._health["TestCh"] = {"success": 0, "failure": 0}
+
+        results = await manager.send_anomaly_alert([])
+        assert results == {}
+        mock_ch.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_anomaly_alert_warning_only(self):
+        """WARNING severity만 있으면 WARNING 레벨"""
+        manager = NotificationManager()
+        mock_ch = AsyncMock()
+        mock_ch.__class__.__name__ = "TestCh"
+        mock_ch.send = AsyncMock(return_value=True)
+        manager.add_channel(mock_ch)
+        manager._health["TestCh"] = {"success": 0, "failure": 0}
+
+        anomalies = [
+            {"type": "EXCESSIVE_TRADING", "severity": "WARNING", "description": "10건 초과"},
+        ]
+        await manager.send_anomaly_alert(anomalies)
+
+        sent_msg = mock_ch.send.call_args[0][0]
+        assert sent_msg.level == NotificationLevel.WARNING

--- a/tests/test_weekly_report.py
+++ b/tests/test_weekly_report.py
@@ -1,0 +1,93 @@
+"""scripts/weekly_report.py 단위 테스트"""
+
+from scripts.weekly_report import (
+    format_performance_stats,
+    get_weekly_performance_stats,
+)
+from src.position_tracker import Position
+from src.types import Direction
+
+
+def make_closed_position(
+    symbol: str,
+    pnl: float,
+    exit_date: str,
+    system: int = 1,
+) -> Position:
+    """테스트용 청산 Position 객체"""
+    return Position(
+        position_id=f"{symbol}_{exit_date}",
+        symbol=symbol,
+        system=system,
+        direction=Direction.LONG,
+        entry_date="2026-01-01",
+        entry_price=100.0,
+        entry_n=2.0,
+        units=1,
+        max_units=4,
+        shares_per_unit=10,
+        total_shares=10,
+        stop_loss=96.0,
+        pyramid_level=0,
+        exit_period=10,
+        status="closed",
+        last_update=exit_date,
+        exit_date=exit_date,
+        exit_price=100.0 + pnl / 10,
+        exit_reason="exit_signal",
+        pnl=pnl,
+        pnl_pct=pnl / 1000,
+        r_multiple=pnl / 40,
+    )
+
+
+class TestWeeklyPerformanceStats:
+    def test_weekly_report_includes_performance_stats(self):
+        """주간 성과 통계에 win_rate, avg_r, total_pnl, profit_factor 포함"""
+        trades = [
+            make_closed_position("SPY", 200.0, "2026-03-10"),
+            make_closed_position("QQQ", -100.0, "2026-03-09"),
+            make_closed_position("IWM", 150.0, "2026-03-08"),
+        ]
+
+        stats = get_weekly_performance_stats(trades)
+
+        assert "win_rate" in stats
+        assert "avg_r" in stats
+        assert "total_pnl" in stats
+        assert "profit_factor" in stats
+        # 3건 중 2건 승리 = 2/3
+        assert abs(stats["win_rate"] - 2 / 3) < 0.01
+        assert stats["total_pnl"] == 250.0
+        assert stats["profit_factor"] > 0
+
+    def test_weekly_report_empty_trades(self):
+        """거래가 없으면 모든 통계가 0"""
+        stats = get_weekly_performance_stats([])
+
+        assert stats["win_rate"] == 0.0
+        assert stats["avg_r"] == 0.0
+        assert stats["total_pnl"] == 0.0
+        assert stats["profit_factor"] == 0.0
+
+
+class TestFormatPerformanceStats:
+    def test_format_with_data(self):
+        """통계가 있으면 승률/R/PnL/PF 포맷"""
+        stats = {
+            "win_rate": 0.65,
+            "avg_r": 1.5,
+            "total_pnl": 2500.0,
+            "profit_factor": 2.1,
+        }
+        result = format_performance_stats(stats)
+        assert "65.0%" in result
+        assert "1.50" in result
+        assert "$+2,500" in result
+        assert "2.10" in result
+
+    def test_format_empty(self):
+        """거래 없으면 '없음' 메시지"""
+        stats = {"win_rate": 0, "avg_r": 0, "total_pnl": 0, "profit_factor": 0}
+        result = format_performance_stats(stats)
+        assert "청산 거래 없음" in result


### PR DESCRIPTION
## Summary
- `src/notifier.py`: `send_pnl_summary()`, `send_performance_alert()`, `send_anomaly_alert()` 3개 메서드 추가
- `scripts/daily_report.py`: 일일 PnL 요약 (실현/미실현), spot_price API 실패 시 graceful degradation
- `scripts/weekly_report.py`: 주간 성과 통계 섹션 (승률, R-배수, Profit Factor)
- `scripts/check_positions.py`: `detect_anomalies()` 통합 — 과대 손실/과잉 매매/연속 손실/과대 노출 감지
- 테스트: notifier 6개 + daily_report 3개 + weekly_report 4개 = 13개 신규

## Test plan
- [x] `test_send_pnl_summary` — PnL 요약 메시지 포맷
- [x] `test_send_pnl_summary_unrealized_na` — 미실현 N/A 처리
- [x] `test_send_performance_alert` — 성과 통계 포함
- [x] `test_send_anomaly_alert` — 이상 거래 포맷 + 심각도별 레벨
- [x] `test_send_anomaly_alert_empty` — 빈 리스트 미전송
- [x] `test_daily_report_includes_pnl_summary` — 일일 리포트 PnL 섹션
- [x] `test_daily_report_spot_price_failure_graceful` — API 실패 시 N/A fallback
- [x] `test_weekly_report_includes_performance_stats` — 주간 성과 통계
- [x] `test_weekly_report_empty_trades` — 빈 거래 처리
- [x] 전체 1,253개 테스트 통과 (회귀 없음)

Fixes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)