### PR TITLE
fix: v3.9.0 코드 품질 개선 — mock spec, 이상감지 테스트, 로깅

### DIFF
--- a/pages/dashboard.py
+++ b/pages/dashboard.py
@@ -7,6 +7,7 @@
 - 30일 PnL 미니 차트
 """
 
+import logging
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -15,6 +16,8 @@ import streamlit as st
 
 from src.indicators import add_turtle_indicators
 from src.position_tracker import PositionTracker
+
+logger = logging.getLogger(__name__)
 
 
 def render(data_fetcher, data_store, universe, symbols, period):
@@ -104,7 +107,8 @@ def _render_open_positions():
                     delta=f"Units: {pos.units}/{pos.max_units}",
                 )
                 st.caption(f"Stop: ${pos.stop_loss:.2f} | System {pos.system}")
-    except Exception:
+    except Exception as e:
+        logger.warning(f"포지션 로드 실패: {e}", exc_info=True)
         st.info("포지션 데이터를 불러올 수 없습니다.")
 
 

--- a/pages/performance.py
+++ b/pages/performance.py
@@ -54,14 +54,15 @@ def render(data_fetcher, data_store, universe, **kwargs):
         return
 
     analytics = TradeAnalytics(trades)
+    initial_capital = kwargs.get("initial_capital", 100000)
 
     # 메트릭 카드 행
-    _render_metric_cards(analytics)
+    _render_metric_cards(analytics, initial_capital=initial_capital)
 
     st.divider()
 
     # 에쿼티 커브 + 드로다운
-    _render_equity_curve(analytics)
+    _render_equity_curve(analytics, initial_capital=initial_capital)
 
     st.divider()
 
@@ -117,7 +118,7 @@ def _filter_by_period(trades, months):
     return filtered
 
 
-def _render_metric_cards(analytics):
+def _render_metric_cards(analytics, *, initial_capital: int = 100000):
     """메트릭 카드 행."""
     stats = analytics.get_win_loss_stats()
     expectancy = analytics.get_expectancy()
@@ -133,7 +134,7 @@ def _render_metric_cards(analytics):
         st.metric("기대값 (E)", f"{expectancy:.3f}R")
     with col5:
         # MDD 게이지
-        equity_curve = analytics.get_equity_curve(initial_capital=100000)
+        equity_curve = analytics.get_equity_curve(initial_capital=initial_capital)
         if equity_curve:
             equity_values = [p["equity"] for p in equity_curve]
             dd_analysis = analytics.get_drawdown_analysis(equity_values)
@@ -142,11 +143,11 @@ def _render_metric_cards(analytics):
             st.metric("MDD", "N/A")
 
 
-def _render_equity_curve(analytics):
+def _render_equity_curve(analytics, *, initial_capital: int = 100000):
     """에쿼티 커브 + 드로다운 영역."""
     st.subheader("에쿼티 커브")
 
-    curve_data = analytics.get_equity_curve(initial_capital=100000)
+    curve_data = analytics.get_equity_curve(initial_capital=initial_capital)
     if not curve_data:
         st.info("에쿼티 커브를 생성할 수 없습니다.")
         return

--- a/scripts/check_positions.py
+++ b/scripts/check_positions.py
@@ -580,9 +580,16 @@ async def _run_checks():
 
     # 5. 이상 거래 감지
     try:
+        from datetime import timedelta
+
         from src.analytics import detect_anomalies
 
-        closed_positions = [p for p in tracker.get_all_positions() if p.status == "closed"]
+        lookback_cutoff = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+        closed_positions = [
+            p
+            for p in tracker.get_all_positions()
+            if p.status == "closed" and p.exit_date and p.exit_date >= lookback_cutoff
+        ]
         recent_trade_dicts = []
         for p in closed_positions:
             recent_trade_dicts.append(

--- a/tests/test_check_positions_anomaly.py
+++ b/tests/test_check_positions_anomaly.py
@@ -1,0 +1,138 @@
+"""
+check_positions.py 이상 거래 감지 흐름 통합 테스트
+
+검증 항목:
+- closed position → trade dict 직렬화 정확성
+- 30일 룩백 필터링 (M4 fix)
+- detect_anomalies + send_anomaly_alert 흐름
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.analytics import detect_anomalies
+from src.position_tracker import Direction, Position
+
+
+def _make_position(symbol: str, exit_date: str, pnl: float = 500.0, status: str = "closed") -> Position:
+    """테스트용 Position 객체 생성"""
+    return Position(
+        position_id=f"{symbol}_{exit_date}",
+        symbol=symbol,
+        system=1,
+        direction=Direction.LONG,
+        entry_date="2026-01-01",
+        entry_price=100.0,
+        entry_n=2.0,
+        units=1,
+        max_units=4,
+        shares_per_unit=10,
+        total_shares=10,
+        stop_loss=96.0,
+        pyramid_level=0,
+        exit_period=10,
+        status=status,
+        last_update=exit_date,
+        exit_date=exit_date,
+        exit_price=100.0 + pnl / 10,
+        exit_reason="stop",
+        pnl=pnl,
+        pnl_pct=pnl / 1000,
+        r_multiple=pnl / 20,
+    )
+
+
+def _serialize_and_filter(positions, lookback_days=30):
+    """check_positions.py 섹션 5의 직렬화/필터링 로직 재현"""
+    lookback_cutoff = (datetime.now() - timedelta(days=lookback_days)).strftime("%Y-%m-%d")
+    closed = [
+        p for p in positions if p.status == "closed" and p.exit_date and p.exit_date >= lookback_cutoff
+    ]
+    trade_dicts = []
+    for p in closed:
+        trade_dicts.append(
+            {
+                "symbol": p.symbol,
+                "system": p.system,
+                "direction": p.direction.value if hasattr(p.direction, "value") else p.direction,
+                "entry_price": p.entry_price,
+                "exit_price": p.exit_price,
+                "stop_loss": p.stop_loss,
+                "total_shares": p.total_shares,
+                "pnl": p.pnl,
+                "exit_date": p.exit_date,
+            }
+        )
+    return trade_dicts
+
+
+class TestAnomalyDetectionFlow:
+    def test_closed_positions_serialized_correctly(self):
+        """closed position → trade dict 직렬화가 정확하다"""
+        recent = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
+        pos = _make_position("SPY", recent, pnl=500.0)
+        result = _serialize_and_filter([pos])
+
+        assert len(result) == 1
+        assert result[0]["symbol"] == "SPY"
+        assert result[0]["direction"] == "LONG"
+        assert result[0]["pnl"] == 500.0
+        assert result[0]["stop_loss"] == 96.0
+
+    def test_old_positions_filtered_out(self):
+        """exit_date가 30일 초과인 포지션은 필터링된다"""
+        old_date = (datetime.now() - timedelta(days=45)).strftime("%Y-%m-%d")
+        recent_date = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
+
+        positions = [
+            _make_position("GLD", old_date, pnl=-5000.0),
+            _make_position("SPY", recent_date, pnl=200.0),
+        ]
+        result = _serialize_and_filter(positions)
+
+        assert len(result) == 1
+        assert result[0]["symbol"] == "SPY"
+
+    def test_open_positions_excluded(self):
+        """status='open'인 포지션은 제외된다"""
+        recent = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d")
+        pos = _make_position("QQQ", recent, status="open")
+        result = _serialize_and_filter([pos])
+
+        assert len(result) == 0
+
+    def test_detect_anomalies_with_large_loss(self):
+        """큰 손실 포지션은 이상 거래로 감지된다"""
+        recent = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d")
+        pos = _make_position("SPY", recent, pnl=-15000.0)
+        trade_dicts = _serialize_and_filter([pos])
+
+        anomalies = detect_anomalies(trade_dicts, account_equity=100000.0)
+        assert len(anomalies) > 0
+
+    def test_no_anomalies_with_normal_trades(self):
+        """정상 거래는 이상 거래로 감지되지 않는다"""
+        recent = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d")
+        pos = _make_position("GLD", recent, pnl=200.0)
+        trade_dicts = _serialize_and_filter([pos])
+
+        anomalies = detect_anomalies(trade_dicts, account_equity=100000.0)
+        assert len(anomalies) == 0
+
+    @pytest.mark.asyncio
+    async def test_anomaly_alert_sent_when_detected(self):
+        """이상 거래 감지 → notifier.send_anomaly_alert() 호출"""
+        notifier = MagicMock()
+        notifier.send_anomaly_alert = AsyncMock(return_value={})
+
+        recent = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d")
+        positions = [_make_position("SPY", recent, pnl=-15000.0)]
+        trade_dicts = _serialize_and_filter(positions)
+        anomalies = detect_anomalies(trade_dicts, account_equity=100000.0)
+
+        if anomalies:
+            await notifier.send_anomaly_alert(anomalies)
+
+        notifier.send_anomaly_alert.assert_awaited_once()

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -6,13 +6,15 @@ import pandas as pd
 import pytest
 
 from scripts.daily_report import generate_pnl_summary, generate_report
+from src.data_store import ParquetDataStore
+from src.position_tracker import PositionTracker
 
 
 class TestGenerateReport:
     @pytest.mark.asyncio
     async def test_daily_report_includes_pnl_summary(self):
         """generate_report 결과에 pnl_summary 섹션이 포함된다"""
-        mock_data_store = MagicMock()
+        mock_data_store = MagicMock(spec=ParquetDataStore)
         mock_data_store.load_signals.return_value = pd.DataFrame()
         mock_data_store.load_trades.return_value = pd.DataFrame()
         mock_data_store.get_cache_stats.return_value = {"cache_files": 0, "total_size_mb": 0.0}
@@ -50,7 +52,7 @@ class TestGeneratePnlSummary:
     @pytest.mark.asyncio
     async def test_daily_report_spot_price_failure_graceful(self):
         """spot_price API 실패 시 미실현 PnL은 N/A로 표시"""
-        mock_tracker = MagicMock()
+        mock_tracker = MagicMock(spec=PositionTracker)
         mock_pos = MagicMock()
         mock_pos.symbol = "SPY"
         mock_pos.direction.value = "LONG"

--- a/tests/test_monthly_report.py
+++ b/tests/test_monthly_report.py
@@ -14,7 +14,7 @@ from scripts.monthly_report import (
     get_previous_month,
     parse_month,
 )
-from src.position_tracker import Direction, Position
+from src.position_tracker import Direction, Position, PositionTracker
 
 # ── 헬퍼 ────────────────────────────────────────────────────────────────────
 
@@ -54,13 +54,15 @@ def make_position(
 
 
 def make_mock_tracker(positions: list) -> MagicMock:
-    tracker = MagicMock()
+    tracker = MagicMock(spec=PositionTracker)
     tracker.get_all_positions.return_value = positions
     return tracker
 
 
 def make_mock_data_store() -> MagicMock:
-    return MagicMock()
+    from src.data_store import ParquetDataStore
+
+    return MagicMock(spec=ParquetDataStore)
 
 
 # ── test_parse_month_default ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
v3.9.0 코드 리뷰에서 식별된 MEDIUM/LOW 이슈 5건 수정

- **M3**: `test_daily_report.py`, `test_monthly_report.py`에 `spec=` 추가 — API 드리프트 방지
- **M4**: `check_positions.py` 이상 거래 감지 시 30일 룩백 사전 필터링 (불필요한 직렬화 제거)
- **M6**: `test_check_positions_anomaly.py` 통합 테스트 6건 추가 (직렬화, 필터링, detect_anomalies, alert 흐름)
- **L1**: `pages/performance.py`에서 `initial_capital` 파라미터화 (하드코딩 100000 제거)
- **L4**: `pages/dashboard.py` 포지션 로드 실패 시 예외 로깅 추가

## Test plan
- [x] `pytest tests/test_daily_report.py` — 4/4 통과
- [x] `pytest tests/test_monthly_report.py` — 13/13 통과
- [x] `pytest tests/test_check_positions_anomaly.py` — 6/6 통과
- [x] `pytest tests/` — 1,259 전체 통과
- [x] `ruff check src/ scripts/ pages/` — clean
- [x] `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)