### PR TITLE
[#208] fix: go_live_check.py OHLCV/백테스트 경로 불일치 수정

### DIFF
--- a/scripts/go_live_check.py
+++ b/scripts/go_live_check.py
@@ -5,7 +5,6 @@
 """
 
 import argparse
-import json
 import logging
 import sys
 from datetime import datetime, timedelta
@@ -109,12 +108,12 @@ def check_data_integrity() -> tuple[bool, str]:
 
 def check_recent_ohlcv() -> tuple[bool, str]:
     """체크 6: 최근 OHLCV 데이터 존재 (2일 이내 — 주말 포함)"""
-    cache_dir = PROJECT_ROOT / "data" / "cache"
-    if not cache_dir.exists():
-        return False, "data/cache/ 디렉토리 없음"
-    parquet_files = list(cache_dir.glob("*.parquet"))
+    ohlcv_dir = PROJECT_ROOT / "data" / "ohlcv"
+    if not ohlcv_dir.exists():
+        return False, "data/ohlcv/ 디렉토리 없음"
+    parquet_files = list(ohlcv_dir.glob("*.parquet"))
     if not parquet_files:
-        return False, "캐시된 OHLCV 데이터 없음"
+        return False, "OHLCV 데이터 없음"
     newest = max(parquet_files, key=lambda p: p.stat().st_mtime)
     age = datetime.now() - datetime.fromtimestamp(newest.stat().st_mtime)
     if age > timedelta(days=2):
@@ -137,30 +136,39 @@ def check_kill_switch() -> tuple[bool, str]:
 
 def check_backtest_performance() -> tuple[bool, str]:
     """체크 8: 백테스트 최소 성과 (30일 이내, MDD < 30%, PF > 1.0)"""
-    backtest_dir = PROJECT_ROOT / "data" / "backtest"
+    backtest_dir = PROJECT_ROOT / "data" / "backtest_results"
     if not backtest_dir.exists():
-        return False, "data/backtest/ 디렉토리 없음"
-    json_files = sorted(
-        backtest_dir.glob("*.json"),
+        return False, "data/backtest_results/ 디렉토리 없음"
+    csv_files = sorted(
+        backtest_dir.glob("*.csv"),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
-    if not json_files:
-        return False, "백테스트 결과 파일 없음"
-    newest = json_files[0]
+    if not csv_files:
+        return False, "백테스트 결과 CSV 없음"
+    newest = csv_files[0]
     age = datetime.now() - datetime.fromtimestamp(newest.stat().st_mtime)
     if age > timedelta(days=30):
         return False, f"최신 백테스트가 {age.days}일 전 (30일 이내 필요)"
     try:
-        with open(newest) as f:
-            result = json.load(f)
-        mdd_raw = result.get("max_drawdown", result.get("max_drawdown_pct"))
-        if mdd_raw is None:
-            return False, "백테스트 결과에 max_drawdown 필드 없음"
-        mdd = abs(mdd_raw)
-        pf = result.get("profit_factor")
-        if pf is None:
-            return False, "백테스트 결과에 profit_factor 필드 없음"
+        import pandas as pd
+
+        df = pd.read_csv(newest)
+        if "pnl" not in df.columns or len(df) == 0:
+            return False, "백테스트 CSV에 pnl 데이터 없음"
+
+        # Profit Factor
+        gains = df.loc[df["pnl"] > 0, "pnl"].sum()
+        losses = abs(df.loc[df["pnl"] < 0, "pnl"].sum())
+        pf = gains / losses if losses > 0 else float("inf")
+
+        # Max Drawdown (equity curve = initial_capital + cumulative PnL)
+        initial_capital = 100_000.0  # run_backtest.py default
+        equity = initial_capital + df["pnl"].cumsum()
+        peak = equity.cummax()
+        drawdown_pct = (equity - peak) / peak
+        mdd = abs(drawdown_pct.min())
+
         issues = []
         if mdd > 0.3:
             issues.append(f"MDD {mdd:.1%} > 30%")
@@ -168,7 +176,7 @@ def check_backtest_performance() -> tuple[bool, str]:
             issues.append(f"PF {pf:.2f} < 1.0")
         if issues:
             return False, "; ".join(issues)
-        return True, f"MDD: {mdd:.1%}, PF: {pf:.2f} (기준 충족)"
+        return True, f"MDD: {mdd:.1%}, PF: {pf:.2f} ({newest.name})"
     except Exception as e:
         return False, f"백테스트 결과 파싱 실패: {e}"
 

--- a/tests/test_go_live_check.py
+++ b/tests/test_go_live_check.py
@@ -1,6 +1,5 @@
 """tests/test_go_live_check.py — Go-Live 자동 검증 체크리스트 테스트."""
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -183,7 +182,7 @@ def test_data_integrity_check_missing(tmp_path):
 
 def test_recent_ohlcv_exists(tmp_path):
     """최신 parquet 파일이 2일 이내면 True."""
-    cache_dir = tmp_path / "data" / "cache"
+    cache_dir = tmp_path / "data" / "ohlcv"
     cache_dir.mkdir(parents=True)
     parquet = cache_dir / "SPY_1d.parquet"
     parquet.write_bytes(b"fake")
@@ -200,7 +199,7 @@ def test_recent_ohlcv_stale(tmp_path):
     import os
     import time
 
-    cache_dir = tmp_path / "data" / "cache"
+    cache_dir = tmp_path / "data" / "ohlcv"
     cache_dir.mkdir(parents=True)
     parquet = cache_dir / "SPY_1d.parquet"
     parquet.write_bytes(b"fake")
@@ -226,7 +225,7 @@ def test_recent_ohlcv_no_cache_dir(tmp_path):
 
 def test_recent_ohlcv_empty_cache(tmp_path):
     """cache 디렉토리는 있지만 parquet 없으면 False."""
-    cache_dir = tmp_path / "data" / "cache"
+    cache_dir = tmp_path / "data" / "ohlcv"
     cache_dir.mkdir(parents=True)
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_recent_ohlcv()
@@ -274,10 +273,15 @@ def test_kill_switch_disabled():
 
 def test_backtest_performance_pass(tmp_path):
     """MDD < 30%, PF > 1.0인 최신 백테스트 결과면 True."""
-    bt_dir = tmp_path / "data" / "backtest"
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.15, "profit_factor": 1.5}
-    (bt_dir / "result_2026.json").write_text(json.dumps(result))
+    csv_content = (
+        "symbol,direction,entry_date,entry_price,exit_date,exit_price,quantity,pnl,pnl_pct,exit_reason\n"
+        "SPY,LONG,2024-01-01,100.0,2024-02-01,110.0,100,1000.0,10.0,exit_long\n"
+        "QQQ,LONG,2024-02-01,200.0,2024-03-01,195.0,50,-250.0,-2.5,stop_loss\n"
+        "SPY,LONG,2024-03-01,105.0,2024-04-01,115.0,100,1000.0,9.52,exit_long\n"
+    )
+    (bt_dir / "result_2026.csv").write_text(csv_content)
 
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
@@ -289,10 +293,14 @@ def test_backtest_performance_pass(tmp_path):
 
 def test_backtest_performance_fail_mdd(tmp_path):
     """MDD > 30%면 False."""
-    bt_dir = tmp_path / "data" / "backtest"
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.35, "profit_factor": 1.5}
-    (bt_dir / "result_2026.json").write_text(json.dumps(result))
+    csv_content = (
+        "symbol,direction,entry_date,entry_price,exit_date,exit_price,quantity,pnl,pnl_pct,exit_reason\n"
+        "SPY,LONG,2024-01-01,100.0,2024-02-01,110.0,100,5000.0,10.0,exit_long\n"
+        "QQQ,LONG,2024-02-01,200.0,2024-03-01,130.0,500,-35000.0,-35.0,stop_loss\n"
+    )
+    (bt_dir / "result_2026.csv").write_text(csv_content)
 
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
@@ -303,10 +311,14 @@ def test_backtest_performance_fail_mdd(tmp_path):
 
 def test_backtest_performance_fail_pf(tmp_path):
     """PF < 1.0이면 False."""
-    bt_dir = tmp_path / "data" / "backtest"
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.10, "profit_factor": 0.8}
-    (bt_dir / "result_2026.json").write_text(json.dumps(result))
+    csv_content = (
+        "symbol,direction,entry_date,entry_price,exit_date,exit_price,quantity,pnl,pnl_pct,exit_reason\n"
+        "SPY,LONG,2024-01-01,100.0,2024-02-01,101.0,100,100.0,1.0,exit_long\n"
+        "QQQ,LONG,2024-02-01,200.0,2024-03-01,195.0,100,-500.0,-2.5,stop_loss\n"
+    )
+    (bt_dir / "result_2026.csv").write_text(csv_content)
 
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
@@ -320,11 +332,16 @@ def test_backtest_performance_stale(tmp_path):
     import os
     import time
 
-    bt_dir = tmp_path / "data" / "backtest"
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.10, "profit_factor": 1.5}
-    result_file = bt_dir / "result_old.json"
-    result_file.write_text(json.dumps(result))
+    csv_content = (
+        "symbol,direction,entry_date,entry_price,exit_date,exit_price,quantity,pnl,pnl_pct,exit_reason\n"
+        "SPY,LONG,2024-01-01,100.0,2024-02-01,110.0,100,1000.0,10.0,exit_long\n"
+        "QQQ,LONG,2024-02-01,200.0,2024-03-01,195.0,50,-250.0,-2.5,stop_loss\n"
+        "SPY,LONG,2024-03-01,105.0,2024-04-01,115.0,100,1000.0,9.52,exit_long\n"
+    )
+    result_file = bt_dir / "result_old.csv"
+    result_file.write_text(csv_content)
 
     old_time = time.time() - (31 * 86400)
     os.utime(result_file, (old_time, old_time))
@@ -337,15 +354,15 @@ def test_backtest_performance_stale(tmp_path):
 
 
 def test_backtest_performance_no_dir(tmp_path):
-    """data/backtest/ 없으면 False."""
+    """data/backtest_results/ 없으면 False."""
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
     assert ok is False
 
 
 def test_backtest_performance_no_files(tmp_path):
-    """data/backtest/ 있지만 파일 없으면 False."""
-    (tmp_path / "data" / "backtest").mkdir(parents=True)
+    """data/backtest_results/ 있지만 파일 없으면 False."""
+    (tmp_path / "data" / "backtest_results").mkdir(parents=True)
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
     assert ok is False


### PR DESCRIPTION
## Summary
- `check_recent_ohlcv()`: `data/cache/` → `data/ohlcv/` (실제 collect_daily_ohlcv.py 저장 경로)
- `check_backtest_performance()`: `data/backtest/*.json` → `data/backtest_results/*.csv` (실제 run_backtest.py 출력 경로/포맷)
- MDD 계산: 초기자본(100K) 포함 equity curve 기반으로 정확도 개선
- 테스트 6건 갱신 (CSV fixture, 경로 반영)

Fixes #208

## Test plan
- [x] `pytest tests/test_go_live_check.py` — 39개 전체 통과
- [x] `pytest tests/` — 1,332 passed (기존 test_version.py 1건만 실패, 무관)
- [x] `ruff check` — clean
- [x] `go_live_check.py` 실행 — OHLCV ✓ PASS, 백테스트 MDD 실제 데이터 기반 판정

🤖 Generated with [Claude Code](https://claude.com/claude-code)