### PR TITLE
[#208] fix: go_live_check OHLCV/백테스트 경로 불일치 수정

### DIFF
--- a/scripts/go_live_check.py
+++ b/scripts/go_live_check.py
@@ -5,7 +5,6 @@
 """
 
 import argparse
-import json
 import logging
 import sys
 from datetime import datetime, timedelta
@@ -109,12 +108,12 @@ def check_data_integrity() -> tuple[bool, str]:
 
 def check_recent_ohlcv() -> tuple[bool, str]:
     """체크 6: 최근 OHLCV 데이터 존재 (2일 이내 — 주말 포함)"""
-    cache_dir = PROJECT_ROOT / "data" / "cache"
-    if not cache_dir.exists():
-        return False, "data/cache/ 디렉토리 없음"
-    parquet_files = list(cache_dir.glob("*.parquet"))
+    ohlcv_dir = PROJECT_ROOT / "data" / "ohlcv"
+    if not ohlcv_dir.exists():
+        return False, "data/ohlcv/ 디렉토리 없음"
+    parquet_files = list(ohlcv_dir.glob("*.parquet"))
     if not parquet_files:
-        return False, "캐시된 OHLCV 데이터 없음"
+        return False, "OHLCV 데이터 없음"
     newest = max(parquet_files, key=lambda p: p.stat().st_mtime)
     age = datetime.now() - datetime.fromtimestamp(newest.stat().st_mtime)
     if age > timedelta(days=2):
@@ -136,39 +135,40 @@ def check_kill_switch() -> tuple[bool, str]:
 
 
 def check_backtest_performance() -> tuple[bool, str]:
-    """체크 8: 백테스트 최소 성과 (30일 이내, MDD < 30%, PF > 1.0)"""
-    backtest_dir = PROJECT_ROOT / "data" / "backtest"
+    """체크 8: 백테스트 최소 성과 (30일 이내, PF > 1.0)"""
+    import csv
+
+    backtest_dir = PROJECT_ROOT / "data" / "backtest_results"
     if not backtest_dir.exists():
-        return False, "data/backtest/ 디렉토리 없음"
-    json_files = sorted(
-        backtest_dir.glob("*.json"),
+        return False, "data/backtest_results/ 디렉토리 없음"
+    csv_files = sorted(
+        backtest_dir.glob("*.csv"),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
-    if not json_files:
+    if not csv_files:
         return False, "백테스트 결과 파일 없음"
-    newest = json_files[0]
+    newest = csv_files[0]
     age = datetime.now() - datetime.fromtimestamp(newest.stat().st_mtime)
     if age > timedelta(days=30):
         return False, f"최신 백테스트가 {age.days}일 전 (30일 이내 필요)"
     try:
-        with open(newest) as f:
-            result = json.load(f)
-        mdd_raw = result.get("max_drawdown", result.get("max_drawdown_pct"))
-        if mdd_raw is None:
-            return False, "백테스트 결과에 max_drawdown 필드 없음"
-        mdd = abs(mdd_raw)
-        pf = result.get("profit_factor")
-        if pf is None:
-            return False, "백테스트 결과에 profit_factor 필드 없음"
+        with open(newest, newline="") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        if not rows:
+            return False, "백테스트 CSV에 거래 데이터 없음"
+        if "pnl" not in rows[0]:
+            return False, "백테스트 CSV에 pnl 컬럼 없음"
+        wins = sum(float(r["pnl"]) for r in rows if float(r["pnl"]) > 0)
+        losses = sum(abs(float(r["pnl"])) for r in rows if float(r["pnl"]) <= 0)
+        pf = wins / losses if losses > 0 else 0
         issues = []
-        if mdd > 0.3:
-            issues.append(f"MDD {mdd:.1%} > 30%")
         if pf < 1.0:
             issues.append(f"PF {pf:.2f} < 1.0")
         if issues:
             return False, "; ".join(issues)
-        return True, f"MDD: {mdd:.1%}, PF: {pf:.2f} (기준 충족)"
+        return True, f"PF: {pf:.2f} ({len(rows)}건 거래, 기준 충족)"
     except Exception as e:
         return False, f"백테스트 결과 파싱 실패: {e}"
 

--- a/tests/test_go_live_check.py
+++ b/tests/test_go_live_check.py
@@ -1,6 +1,5 @@
 """tests/test_go_live_check.py — Go-Live 자동 검증 체크리스트 테스트."""
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -183,9 +182,9 @@ def test_data_integrity_check_missing(tmp_path):
 
 def test_recent_ohlcv_exists(tmp_path):
     """최신 parquet 파일이 2일 이내면 True."""
-    cache_dir = tmp_path / "data" / "cache"
-    cache_dir.mkdir(parents=True)
-    parquet = cache_dir / "SPY_1d.parquet"
+    ohlcv_dir = tmp_path / "data" / "ohlcv"
+    ohlcv_dir.mkdir(parents=True)
+    parquet = ohlcv_dir / "000080_ohlcv.parquet"
     parquet.write_bytes(b"fake")
 
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
@@ -200,9 +199,9 @@ def test_recent_ohlcv_stale(tmp_path):
     import os
     import time
 
-    cache_dir = tmp_path / "data" / "cache"
-    cache_dir.mkdir(parents=True)
-    parquet = cache_dir / "SPY_1d.parquet"
+    ohlcv_dir = tmp_path / "data" / "ohlcv"
+    ohlcv_dir.mkdir(parents=True)
+    parquet = ohlcv_dir / "000080_ohlcv.parquet"
     parquet.write_bytes(b"fake")
 
     # Set mtime to 3 days ago
@@ -216,18 +215,18 @@ def test_recent_ohlcv_stale(tmp_path):
     assert "일 전" in msg
 
 
-def test_recent_ohlcv_no_cache_dir(tmp_path):
-    """cache 디렉토리 없으면 False."""
+def test_recent_ohlcv_no_dir(tmp_path):
+    """ohlcv 디렉토리 없으면 False."""
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_recent_ohlcv()
     assert ok is False
     assert "디렉토리 없음" in msg
 
 
-def test_recent_ohlcv_empty_cache(tmp_path):
-    """cache 디렉토리는 있지만 parquet 없으면 False."""
-    cache_dir = tmp_path / "data" / "cache"
-    cache_dir.mkdir(parents=True)
+def test_recent_ohlcv_empty_dir(tmp_path):
+    """ohlcv 디렉토리는 있지만 parquet 없으면 False."""
+    ohlcv_dir = tmp_path / "data" / "ohlcv"
+    ohlcv_dir.mkdir(parents=True)
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_recent_ohlcv()
     assert ok is False
@@ -272,41 +271,45 @@ def test_kill_switch_disabled():
 # ---------------------------------------------------------------------------
 
 
+def _write_backtest_csv(path: Path, rows: list[dict]) -> None:
+    """헬퍼: 백테스트 CSV 파일 작성."""
+    import csv
+
+    fieldnames = rows[0].keys() if rows else ["symbol", "pnl"]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 def test_backtest_performance_pass(tmp_path):
-    """MDD < 30%, PF > 1.0인 최신 백테스트 결과면 True."""
-    bt_dir = tmp_path / "data" / "backtest"
+    """PF > 1.0인 최신 백테스트 결과면 True."""
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.15, "profit_factor": 1.5}
-    (bt_dir / "result_2026.json").write_text(json.dumps(result))
+    trades = [
+        {"symbol": "SPY", "pnl": "500"},
+        {"symbol": "QQQ", "pnl": "300"},
+        {"symbol": "IWM", "pnl": "-200"},
+    ]
+    _write_backtest_csv(bt_dir / "result_2026.csv", trades)
 
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
 
     assert ok is True
-    assert "MDD" in msg
     assert "PF" in msg
-
-
-def test_backtest_performance_fail_mdd(tmp_path):
-    """MDD > 30%면 False."""
-    bt_dir = tmp_path / "data" / "backtest"
-    bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.35, "profit_factor": 1.5}
-    (bt_dir / "result_2026.json").write_text(json.dumps(result))
-
-    with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
-        ok, msg = go_live_check.check_backtest_performance()
-
-    assert ok is False
-    assert "MDD" in msg
+    assert "3건" in msg
 
 
 def test_backtest_performance_fail_pf(tmp_path):
     """PF < 1.0이면 False."""
-    bt_dir = tmp_path / "data" / "backtest"
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.10, "profit_factor": 0.8}
-    (bt_dir / "result_2026.json").write_text(json.dumps(result))
+    trades = [
+        {"symbol": "SPY", "pnl": "100"},
+        {"symbol": "QQQ", "pnl": "-500"},
+    ]
+    _write_backtest_csv(bt_dir / "result_2026.csv", trades)
 
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
@@ -320,11 +323,11 @@ def test_backtest_performance_stale(tmp_path):
     import os
     import time
 
-    bt_dir = tmp_path / "data" / "backtest"
+    bt_dir = tmp_path / "data" / "backtest_results"
     bt_dir.mkdir(parents=True)
-    result = {"max_drawdown": 0.10, "profit_factor": 1.5}
-    result_file = bt_dir / "result_old.json"
-    result_file.write_text(json.dumps(result))
+    trades = [{"symbol": "SPY", "pnl": "500"}]
+    result_file = bt_dir / "result_old.csv"
+    _write_backtest_csv(result_file, trades)
 
     old_time = time.time() - (31 * 86400)
     os.utime(result_file, (old_time, old_time))
@@ -337,19 +340,46 @@ def test_backtest_performance_stale(tmp_path):
 
 
 def test_backtest_performance_no_dir(tmp_path):
-    """data/backtest/ 없으면 False."""
+    """data/backtest_results/ 없으면 False."""
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
     assert ok is False
+    assert "디렉토리 없음" in msg
 
 
 def test_backtest_performance_no_files(tmp_path):
-    """data/backtest/ 있지만 파일 없으면 False."""
-    (tmp_path / "data" / "backtest").mkdir(parents=True)
+    """data/backtest_results/ 있지만 파일 없으면 False."""
+    (tmp_path / "data" / "backtest_results").mkdir(parents=True)
     with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
         ok, msg = go_live_check.check_backtest_performance()
     assert ok is False
     assert "없음" in msg
+
+
+def test_backtest_performance_empty_csv(tmp_path):
+    """CSV 헤더만 있고 데이터 없으면 False."""
+    bt_dir = tmp_path / "data" / "backtest_results"
+    bt_dir.mkdir(parents=True)
+    (bt_dir / "empty.csv").write_text("symbol,pnl\n")
+
+    with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
+        ok, msg = go_live_check.check_backtest_performance()
+
+    assert ok is False
+    assert "데이터 없음" in msg
+
+
+def test_backtest_performance_missing_pnl_column(tmp_path):
+    """pnl 컬럼 없으면 False."""
+    bt_dir = tmp_path / "data" / "backtest_results"
+    bt_dir.mkdir(parents=True)
+    (bt_dir / "bad.csv").write_text("symbol,direction\nSPY,LONG\n")
+
+    with patch.object(go_live_check, "PROJECT_ROOT", tmp_path):
+        ok, msg = go_live_check.check_backtest_performance()
+
+    assert ok is False
+    assert "pnl" in msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **OHLCV 경로 수정**: `data/cache` → `data/ohlcv` (collect_daily_ohlcv.py 실제 저장 경로)
- **백테스트 경로/포맷 수정**: `data/backtest/*.json` → `data/backtest_results/*.csv`, CSV 파싱으로 PF 직접 계산
- MDD 체크 제거 (트레이드 CSV에서 equity curve 없이 산출 불가)
- 테스트 8개 갱신 + 2개 추가 (empty CSV, missing pnl column edge cases)

## Test plan
- [x] `ruff check` 통과
- [x] `pytest tests/test_go_live_check.py` 40/40 통과
- [ ] CI lint + test 통과

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)