### PR TITLE
[#211] feat: live 경로 er_at_entry 전파

### DIFF
--- a/scripts/auto_trade.py
+++ b/scripts/auto_trade.py
@@ -211,6 +211,7 @@ def check_entry_signal(df, symbol: str, system: int) -> dict | None:
             "stop_loss": stop_loss,
             "date": today["date"].strftime("%Y-%m-%d") if hasattr(today["date"], "strftime") else str(today["date"]),
             "message": f"System {system} 롱 진입: {entry_price:.2f} 돌파",
+            "er_at_entry": today.get("er"),
         }
 
     return None

--- a/scripts/check_positions.py
+++ b/scripts/check_positions.py
@@ -196,6 +196,7 @@ def check_entry_signals(
                     "stop_loss": yesterday[high_col] - (2 * today["N"]),
                     "date": today["date"].strftime("%Y-%m-%d"),
                     "message": f"System {system} 롱 진입: {yesterday[high_col]:.2f} 돌파",
+                    "er_at_entry": today.get("er"),
                 }
             )
 
@@ -232,6 +233,7 @@ def check_entry_signals(
                         "stop_loss": yesterday[short_low_col] + (2 * today["N"]),  # 숏 스톱은 위로
                         "date": today["date"].strftime("%Y-%m-%d"),
                         "message": f"System {system} 숏 진입: {yesterday[short_low_col]:.2f} 이탈",
+                        "er_at_entry": today.get("er"),
                     }
                 )
 

--- a/src/position_tracker.py
+++ b/src/position_tracker.py
@@ -175,6 +175,7 @@ class PositionTracker:
         shares: int,
         account_equity: float = 100000,
         entry_reason: str | None = None,
+        er_at_entry: float | None = None,
     ) -> Position:
         """새 포지션 생성"""
         if isinstance(direction, str):
@@ -208,6 +209,7 @@ class PositionTracker:
             status=PositionStatus.OPEN.value,
             last_update=datetime.now().isoformat(),
             entry_reason=entry_reason,
+            er_at_entry=er_at_entry,
         )
 
         # 포지션 저장

--- a/tests/test_check_positions.py
+++ b/tests/test_check_positions.py
@@ -415,6 +415,7 @@ class TestSignalStructure:
             "stop_loss",
             "date",
             "message",
+            "er_at_entry",
         }
         assert required_keys.issubset(sig.keys()), f"시그널에 필수 키가 누락됨: {required_keys - sig.keys()}"
 
@@ -456,6 +457,7 @@ class TestSignalStructure:
             "stop_loss",
             "date",
             "message",
+            "er_at_entry",
         }
         assert required_keys.issubset(sig.keys())
 

--- a/tests/test_position_tracker.py
+++ b/tests/test_position_tracker.py
@@ -415,3 +415,29 @@ class TestEntryReason:
         }
         pos = Position.from_dict(data)
         assert pos.entry_reason is None
+
+    def test_open_position_with_er_at_entry(self, tracker):
+        """er_at_entry 전달 시 Position에 저장"""
+        pos = tracker.open_position("SPY", 1, "LONG", 100.0, 2.5, 40, er_at_entry=0.45)
+        assert pos.er_at_entry == 0.45
+
+    def test_open_position_er_at_entry_default_none(self, tracker):
+        """er_at_entry 미전달 시 None"""
+        pos = tracker.open_position("SPY", 1, "LONG", 100.0, 2.5, 40)
+        assert pos.er_at_entry is None
+
+    def test_er_at_entry_round_trip(self, tracker):
+        """er_at_entry to_dict → from_dict 왕복 무결성"""
+        pos = tracker.open_position("SPY", 1, "LONG", 100.0, 2.5, 40, er_at_entry=0.62)
+        d = pos.to_dict()
+        assert d["er_at_entry"] == 0.62
+        restored = Position.from_dict(d)
+        assert restored.er_at_entry == 0.62
+
+    def test_er_at_entry_none_round_trip(self, tracker):
+        """er_at_entry=None to_dict → from_dict 왕복"""
+        pos = tracker.open_position("SPY", 1, "LONG", 100.0, 2.5, 40)
+        d = pos.to_dict()
+        assert d["er_at_entry"] is None
+        restored = Position.from_dict(d)
+        assert restored.er_at_entry is None


### PR DESCRIPTION
## Summary
- `check_positions.py`: 롱/숏 signal dict에 `er_at_entry` 추가 (ER 값 추적)
- `auto_trade.py`: signal dict에 `er_at_entry` 추가
- `position_tracker.py`: `open_position()`에 `er_at_entry` 파라미터 추가 → Position 저장
- 테스트 4개 추가 (er_at_entry round-trip) + signal structure 테스트 2개 갱신

## Test plan
- [x] `ruff check` + `ruff format --check` 통과
- [x] `pytest tests/test_position_tracker.py tests/test_check_positions.py` 144 passed
- [ ] CI lint + test 통과

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)